### PR TITLE
[OBSDEF-4332] Fix Operator RBAC for storagepools

### DIFF
--- a/objectscale-manager/templates/operator-rbac.yaml
+++ b/objectscale-manager/templates/operator-rbac.yaml
@@ -20,17 +20,10 @@ imagePullSecrets:
   - name: {{ .Values.global.registrySecret }}
 {{- end }}
 ---
-{{- if eq .Values.global.watchAllNamespaces true }}
 kind: ClusterRole
-{{- else }}
-kind: Role
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Namespace }}-objectscale-operator
-{{- if ne .Values.global.watchAllNamespaces true }}
-  namespace: {{ .Release.Namespace }}
-{{- end }}
   labels:
     app.kubernetes.io/name: objectscale-manager
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -137,9 +130,10 @@ rules:
 - apiGroups:
   - cns.vmware.com
   resources:
-  - "*"
+  - storagepools
   verbs:
-  - "*"
+    - get
+    - list
 ---
 {{- if eq .Values.global.watchAllNamespaces true }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Purpose
-  Fix Operator RBAC for getting storagepools of PSP
- Storagepools is cluster-level so Operator needs to use `ClusterRole`

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

