### PR TITLE
[OBSDEF-4676] - Add direct access support in support assist

### DIFF
--- a/supportassist/templates/supportassist-cr.yaml
+++ b/supportassist/templates/supportassist-cr.yaml
@@ -26,6 +26,10 @@ spec:
   gateways:
   {{toYaml .Values.gateways | indent 2 | trim}}
   {{- end }}
+  {{- if .Values.directEndpoints }}
+  directEndpoints:
+  {{toYaml .Values.directEndpoints | indent 2 | trim}}
+  {{- end }}
   CloudIQ:
     enabled: false
     inventory: 60

--- a/supportassist/values.yaml
+++ b/supportassist/values.yaml
@@ -51,6 +51,10 @@ useGateways: true
 #    port: 9443
 #    priority: 20
 
+# directEndpoints: - required field to pass using --set
+#  - hostname: esrs3-corestg.isus.emc.com
+#    priority: 20
+
 # contacts - when specifying SupportAssist Customer Contacts directly during deployment
 # contacts:
 #  - contactOrder: 1


### PR DESCRIPTION
## Purpose
[OBSDEF-4676](https://jira.cec.lab.emc.com/browse/OBSDEF-4676)
add direct access support in support assist controller in decks, decks change in https://eos2git.cec.lab.emc.com/atlantic/decks/pull/101

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing

