### PR TITLE
[OBSDEF-4831] Fix healthcheck RBAC

### DIFF
--- a/ecs-cluster/templates/healthcheck-rbac.yaml
+++ b/ecs-cluster/templates/healthcheck-rbac.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: objectstore-healthchecks
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.registrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.registrySecret }}
+  {{- end }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-objectstore-healthchecks
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - ecs.dellemc.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - app.k8s.io
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - secrets
+      - services
+      - endpoints
+      - events
+      - configmaps
+      - applications
+      - deployments
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-objectstore-healthchecks
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: objectstore-healthchecks
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Namespace }}-objectstore-healthchecks
+  apiGroup: rbac.authorization.k8s.io

--- a/ecs-cluster/templates/objectstore-app-configmap.yaml
+++ b/ecs-cluster/templates/objectstore-app-configmap.yaml
@@ -29,11 +29,13 @@ data:
       spec:
         - name: objectstore-healthcheck
           container: {{.Values.global.registry}}/objectstore-connectivity:{{.Values.tag}}
+          serviceaccount: "objectstore-healthchecks"
           schedule: "0 */6 * * *"
           timelimit: "5m"
           args:
             - all
         - name: objectstore-pre-update
           container: {{.Values.global.registry}}/objectstore-pre-update:{{.Values.tag}}
+          serviceaccount: "objectstore-healthchecks"
           schedule: "*/30 * * * *"
           timelimit: "5m"


### PR DESCRIPTION
The health checks run may need to list things like ecsclusters to figure out
if the state of the component is healthy (in objectstore-pre-update check's
case). Use a new job-runner service account for this which lets us fine tune
RBAC for health checks without overloading existing serviceaccounts. This
does not use the KAHM service account because job-runner covers only its
specific namespace, while kahm might have access to other namespaces.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
https://jira.cec.lab.emc.com/browse/OBSDEF-4831

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

