### PR TITLE
Draft [OBSDEF-4833] Fix being unable setup SupportAssist in different namespace once another one is already setup

### DIFF
--- a/supportassist/templates/notifier-rbac.yaml
+++ b/supportassist/templates/notifier-rbac.yaml
@@ -16,6 +16,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{.Release.Namespace}}-supportassist-{{required "product must be specified" .Values.product}}-notifier
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: supportassist-{{required "product must be specified" .Values.product}}-notifier
 {{ include "supportassist.labels" . | indent 4 }}
@@ -39,6 +40,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{.Release.Namespace}}-supportassist-{{required "product must be specified" .Values.product}}-notifier
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: supportassist-{{required "product must be specified" .Values.product}}-notifier
 {{ include "supportassist.labels" . | indent 4 }}


### PR DESCRIPTION
## Purpose
[OBSDEF-4388](https://jira.cec.lab.emc.com/browse/OBSDEF-4833)
Add namespace key for ClusterRole and ClusterRoleBinding to fix unable setup SupportAssist in different namespace once another one is already setup.

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

