### PR TITLE
OBSDEF-4865 - remove LoadBalancer service setting for ESE pod/svc

### DIFF
--- a/supportassist/templates/supportassist.yaml
+++ b/supportassist/templates/supportassist.yaml
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/component: supportassist-{{.Values.product}}-ese
 {{ include "supportassist.labels" . | indent 4 }}
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - name: secure
     port: 9447


### PR DESCRIPTION
## Purpose
[OBSDEF-4865](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-4865)
- Remove LoadBalancer from supportassist k8s service

## PR checklist
- [x] make test passed
- [ ] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
```
helm install sa ./supportassist --set product=objectscale,productVersion=0.64.0,siteID=11145366,pin=5555,gateways[0].hostname="10.1.1.1",gateways[0].port=9443,gateways[0].priority=20 --set global.registry=asdrepo.isus.emc.com:9042 --set accessKey=6F27BE20

└─ $ ▶  kubectl get svc
NAME                                     TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
decks-support-store                      ClusterIP   10.96.168.25    <none>        7443/TCP            5m36s
kahm-headless                            ClusterIP   None            <none>        60000/TCP           5m52s
kahm-restapi                             ClusterIP   10.96.183.122   <none>        17999/TCP           5m52s
kubernetes                               ClusterIP   10.96.0.1       <none>        443/TCP             27d
supportassist-objectscale                ClusterIP   10.96.223.26    <none>        9447/TCP,8080/TCP   4m18s
supportassist-objectscale-ese-callback   ClusterIP   10.96.21.66     <none>        9447/TCP            4m18s
supportassist-objectscale-notifier       ClusterIP   10.96.160.225   <none>        50051/TCP           4m18s
supportassist-objectscale-store-svc      ClusterIP   10.96.73.119    <none>        7443/TCP            4m18s
```

