### PR TITLE
[OBSDEF-4989] ConfigMaps for repsvc

### DIFF
--- a/ecs-cluster/svc-configs/rep/repsvc-log4j2.xml
+++ b/ecs-cluster/svc-configs/rep/repsvc-log4j2.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration  monitorInterval="60" shutdownHook="disable">
+    <Appenders>
+        <RollingFile name="R" fileName="${sys:product.home}/logs/repsvc.log"
+                     filePattern="${sys:product.home}/logs/repsvc.log.%i">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} [%t] %5p  %F (line %L) %m%n%ex</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="5 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+        </RollingFile>
+
+        <RollingFile name="P" fileName="${sys:product.home}/logs/repsvc-perf-counter.log"
+                     filePattern="${sys:product.home}/logs/repsvc-perf-counter.log.%i">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} %m%n%ex</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="5 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+        </RollingFile>
+
+        <RollingFile name="E" fileName="${sys:product.home}/logs/repsvc-error.log"
+                     filePattern="${sys:product.home}/logs/repsvc-error.log.%i">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} [%t] %5p  %F (line %L) %m%n%ex</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="5 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+        </RollingFile>
+
+        <RollingFile name="M" fileName="${sys:product.home}/logs/repsvc-stats.log"
+                     filePattern="${sys:product.home}/logs/repsvc-stats.log.%i">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} [%t] %5p  %F (line %L) %m%n%ex</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="5 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="1"/>
+        </RollingFile>
+
+        <Syslog name="alertsLogger" host="localhost" port="514" protocol="UDP" facility="LOCAL7"/>
+
+        <Async name="asyncR" includeLocation="true">
+            <AppenderRef ref="R"/>
+        </Async>
+        <Async name="asyncE" includeLocation="true">
+            <AppenderRef ref="E"/>
+        </Async>
+        <Async name="asyncP" includeLocation="true">
+            <AppenderRef ref="P"/>
+        </Async>
+        <Async name="asyncM" includeLocation="true">
+            <AppenderRef ref="M"/>
+        </Async>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.perf4j.TimingLogger" level="ERROR"/>
+
+        <Logger name="com.emc.storageos.services.util.AlertsLogger" level="WARN" additivity="false">
+            <AppenderRef ref="alertsLogger"/>
+        </Logger>
+        <Logger name="com.emc.storageos.objcontrol.object.shared.PerformanceCounter" level="DEBUG" additivity="false">
+            <AppenderRef ref="asyncP"/>
+        </Logger>
+        <Logger name="com.emc.storageos.data.monitoring.MonitoringWorker" level="INFO">
+            <AppenderRef ref="asyncM"/>
+        </Logger>
+        <Logger name="com.emc.storageos.data.object.impl.buffer" level="INFO">
+            <AppenderRef ref="asyncM"/>
+        </Logger>
+
+        <Root level="INFO">
+            <AppenderRef ref="asyncR"/>
+            <AppenderRef ref="asyncE" level="error"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/ecs-cluster/templates/svc-configs.yaml
+++ b/ecs-cluster/templates/svc-configs.yaml
@@ -1,4 +1,4 @@
-{{- range $i, $svc := list "blob" "cm" "control" "cp" "diagnostic" "event" "geo" "metering" "rm" "resource" "s3" "sr" "sm" "ssm" "objectsvc" "storageserver" }}
+{{- range $i, $svc := list "blob" "cm" "control" "cp" "diagnostic" "event" "geo" "metering" "rm" "rep" "resource" "s3" "sr" "sm" "ssm" "objectsvc" "storageserver" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/ecs-cluster/templates/svc-configs.yaml
+++ b/ecs-cluster/templates/svc-configs.yaml
@@ -17,3 +17,23 @@ metadata:
 data:
 {{ ($.Files.Glob (print "svc-configs/" $svc "/*")).AsConfig | indent 2 }}
 {{- end }}
+
+{{- range $i, $svc := list "rep" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{$.Release.Name}}-{{$svc}}-conf
+  namespace: {{$.Release.namespace}}
+  labels:
+    app.kubernetes.io/name: {{$.Release.Name}}
+    app.kubernetes.io/version: {{$.Values.tag}}
+    app.kubernetes.io/instance: {{$.Release.Name}}
+    app.kubernetes.io/managed-by: {{$.Release.Service}}
+    helm.sh/chart: {{$.Chart.Name}}-{{$.Chart.Version | replace "+" "_"}}
+    product: objectscale
+    release: {{$.Release.Name}}
+
+data:
+{{ with $svcMap := $svc | index $.Values }}{{ toYaml $svcMap.extraConfig | indent 2 }}{{ end }}
+{{- end }}

--- a/ecs-cluster/templates/svc-configs.yaml
+++ b/ecs-cluster/templates/svc-configs.yaml
@@ -1,4 +1,4 @@
-{{- range $i, $svc := list "blob" "cm" "control" "cp" "diagnostic" "event" "geo" "metering" "rm" "rep" "resource" "s3" "sr" "sm" "ssm" "objectsvc" "storageserver" }}
+{{- range $i, $svc := list "blob" "cm" "control" "cp" "diagnostic" "event" "geo" "metering" "rm" "resource" "s3" "sr" "sm" "ssm" "objectsvc" "rep" "storageserver" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/ecs-cluster/tests/svc_log4j2_test.yaml
+++ b/ecs-cluster/tests/svc_log4j2_test.yaml
@@ -19,7 +19,7 @@ tests:
       global.monitoring.enabled: false
     asserts:
       - hasDocuments:
-          count: 16
+          count: 18
 
       - equal:
           path: metadata.name
@@ -155,3 +155,12 @@ tests:
           path: data.objectsvc-log4j2\.xml
           pattern: "objectsvc.log"
         documentIndex: 14
+
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rep-log4j2
+        documentIndex: 15
+      - matchRegex:
+          path: data.repsvc-log4j2\.xml
+          pattern: "repsvc.log"
+        documentIndex: 15

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -253,6 +253,8 @@ rep:
     repository: rep
     # tag: stable
     # pullPolicy: IfNotPresent
+  extraConfig:
+    {}
 
 # The ECS storage server manager configuration specification
 storageServerManager:

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -253,6 +253,9 @@ rep:
     repository: rep
     # tag: stable
     # pullPolicy: IfNotPresent
+
+  # Elements to add to the service's ConfigMap. This is a map of string -> string
+  # for ConfigMap data entries. Values may be multiline strings.
   extraConfig:
     {}
 


### PR DESCRIPTION
## Purpose
[OBSDEF-4989](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-4989)

This PR adds a log4j ConfigMap for the `rep` service with a copy of its log4j2 config file.

Another ConfigMap for repsvc-specific configuration is added.  This second ConfigMap is populated by a helm value (empty by default but settable with a `--values` file) and will be mounted into the service pod.  It could contain any service-specific configuration but repsvc needs it to allow injecting a Java properties files to allow configuration settings without having to rebuild images.

The corresponding flex-operator changes are in this PR: https://eos2git.cec.lab.emc.com/ECS/ecs-flex-operator/pull/282


## PR checklist
- [x] make test passed
- [ ] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [x] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing

- **Build** - https://asd-ecs-jenkins.isus.emc.com/jenkins/job/operator-custom-build/438/
- **Test run** - https://asd-ecs-jenkins.isus.emc.com/jenkins/job/ecs-flex-automation-custom-runner/2384/

Since CRR is not enabled in the automated tests, the rep pods don't run there.  I ran this manually in my microk8s to test upgrade:

### Initial install of older operator version

```
dvm> helm install ecs-manager ./objectscale-manager/ --values /home/marka/flexikube-values.yml --set global.monitoring.enabled=false
NAME: ecs-manager
LAST DEPLOYED: Wed Jan 13 11:03:42 2021
...

dvm> helm install ecs1 ./ecs-cluster/ --values /home/marka/flexikube-values.yml --set features.enableCRR=true --set global.monitoring.enabled=false --set blob.image.tag=3.7.0.0-129250.d2e4e1914c4 --set chunkManager.image.tag=3.7.0.0-129250.d2e4e1914c4 --set control.image.tag=3.7.0.0-129250.d2e4e1914c4 --set diagnostic.image.tag=3.7.0.0-129250.d2e4e1914c4 --set event.image.tag=3.7.0.0-129250.d2e4e1914c4 --set geoReceiver.image.tag=3.7.0.0-129250.d2e4e1914c4 --set geoService.image.tag=3.7.0.0-129250.d2e4e1914c4 --set metering.image.tag=3.7.0.0-129250.d2e4e1914c4 --set ons.image.tag=3.7.0.0-129250.d2e4e1914c4 --set rep.image.tag=3.7.0.0-129250.d2e4e1914c4 --set resource.image.tag=3.7.0.0-129250.d2e4e1914c4 --set recordManager.image.tag=3.7.0.0-129250.d2e4e1914c4 --set s3.image.tag=3.7.0.0-129250.d2e4e1914c4 --set spaceReclaimer.image.tag=3.7.0.0-129250.d2e4e1914c4 --set storageServer.image.tag=3.7.0.0-129250.d2e4e1914c4 --set storageServerManager.image.tag=3.7.0.0-129250.d2e4e1914c4 --set storageManagement.image.tag=3.7.0.0-129250.d2e4e1914c4 --set objectsvc.image.tag=3.7.0.0-1434.1fa7cf71
NAME: ecs1
LAST DEPLOYED: Wed Jan 13 11:04:56 2021
...

dvm> kubectl get pods
NAME                                       READY   STATUS      RESTARTS   AGE
atlas-operator-5df6f49d76-8kw45            1/1     Running     0          13m
ecs-manager-service-pod-644c4796db-gb7nw   1/1     Running     0          13m
ecs1-atlas-0                               1/1     Running     0          12m
ecs1-cm-6b4d8d745d-qg8pq                   2/2     Running     0          11m
ecs1-control-644d6b69c4-jdwll              2/2     Running     0          11m
ecs1-diag-6b96bf64bc-gglg5                 2/2     Running     0          11m
ecs1-event-7c886bbdbf-ssv4b                2/2     Running     0          11m
ecs1-geo-54b58b6c5d-dzvl5                  2/2     Running     0          11m
ecs1-geoservice-6976dc8d4d-dr5b6           2/2     Running     0          11m
ecs1-management-gateway-7dc9488899-6tq5l   1/1     Running     0          11m
ecs1-metering-69b6974df4-b2brr             2/2     Running     0          11m
ecs1-objectsvc-789988478f-26vld            2/2     Running     0          11m
ecs1-ons-6986557dfc-5qbr9                  2/2     Running     0          11m
ecs1-provision-vptfl                       0/1     Completed   1          8m52s
ecs1-rep-6bffc56b59-gmd5q                  2/2     Running     0          11m
ecs1-resource-8467556568-pjtwg             2/2     Running     0          11m
ecs1-rm-8449b87555-z4v8w                   2/2     Running     0          11m
ecs1-s3-6bd9dc8c7d-v58st                   2/2     Running     0          11m
ecs1-sr-757555687f-ht7j4                   2/2     Running     0          11m
ecs1-ss-0                                  1/1     Running     0          12m
ecs1-ss-1                                  1/1     Running     0          12m
ecs1-ss-2                                  1/1     Running     0          12m
ecs1-ssm-f8f47698c-pkhwd                   2/2     Running     0          11m
ecs1-zookeeper-0                           1/1     Running     0          12m
objectscale-operator-6b9df877d6-v4gsk      1/1     Running     0          13m
zookeeper-operator-7d5c4c8fb4-4w5f5        1/1     Running     0          13m
```

### Upgrading operator and ecs-cluster

```
dvm> helm upgrade ecs1 ./ecs-cluster/ --values /home/marka/flexikube-values.yml --set features.enableCRR=true --set global.monitoring.enabled=false --set blob.image.tag=3.7.0.0-129250.d2e4e1914c4 --set chunkManager.image.tag=3.7.0.0-129250.d2e4e1914c4 --set control.image.tag=3.7.0.0-129250.d2e4e1914c4 --set diagnostic.image.tag=3.7.0.0-129250.d2e4e1914c4 --set event.image.tag=3.7.0.0-129250.d2e4e1914c4 --set geoReceiver.image.tag=3.7.0.0-129250.d2e4e1914c4 --set geoService.image.tag=3.7.0.0-129250.d2e4e1914c4 --set metering.image.tag=3.7.0.0-129250.d2e4e1914c4 --set ons.image.tag=3.7.0.0-129250.d2e4e1914c4 --set rep.image.tag=3.7.0.0-129250.d2e4e1914c4 --set resource.image.tag=3.7.0.0-129250.d2e4e1914c4 --set recordManager.image.tag=3.7.0.0-129250.d2e4e1914c4 --set s3.image.tag=3.7.0.0-129250.d2e4e1914c4 --set spaceReclaimer.image.tag=3.7.0.0-129250.d2e4e1914c4 --set storageServer.image.tag=3.7.0.0-129250.d2e4e1914c4 --set storageServerManager.image.tag=3.7.0.0-129250.d2e4e1914c4 --set storageManagement.image.tag=3.7.0.0-129250.d2e4e1914c4 --set objectsvc.image.tag=3.7.0.0-1434.1fa7cf71
Release "ecs1" has been upgraded. Happy Helming!
...

dvm> kubectl get cm |grep ecs1-rep
ecs1-rep-conf                             2      17m
ecs1-rep-log4j2                           1      17m
```

```
dvm> helm upgrade ecs-manager ./objectscale-manager/ --values /home/marka/flexikube-values.yml --set global.monitoring.enabled=false --set image.tag=0.64.0-382.5f0148df
Release "ecs-manager" has been upgraded. Happy Helming!
...

dvm> kubectl get pods
...
ecs1-rep-dcc55c986-kzs7k                   2/2     Running       0          2m29s
...
objectscale-operator-9bd99b674-nk2bw       1/1     Running       0          2m50s
...
```

### Validate configmap is mounted in the rep container

```
dvm> kubectl exec ecs1-rep-dcc55c986-kzs7k -- ls -l /srv-conf
Defaulting container name to rep.
Use 'kubectl describe pod/ecs1-rep-dcc55c986-kzs7k -n default' to see all of the containers in this pod.
total 0
lrwxrwxrwx 1 root root 21 Jan 13 16:19 foo.properties -> ..data/foo.properties
lrwxrwxrwx 1 root root 19 Jan 13 16:19 x.properties -> ..data/x.properties
```