### PR TITLE
OBSDEF-5177 - change ese image tag to 2.1.1.55

### DIFF
--- a/supportassist/values.yaml
+++ b/supportassist/values.yaml
@@ -18,7 +18,7 @@ pullPolicy: Always
 # The image configured for dell-ese
 image:
   repository: dell-supportassist-ese
-  tag: 2.1.1.19
+  tag: 2.1.1.55
   # pullPolicy: Always
 
 # Create app resource thru helm


### PR DESCRIPTION
## Purpose
[OBSDEF-5177](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5177)
- Set ESE image tag to 2.1.1.55
- Yes this is static because we only change this once every 2 months.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
Ran helm install of newly build 2.1.1.55 image,  testing worked great standalone and w decks

