### PR TITLE
[OBSDEF-5008] - remove autoclear timeout, add event to clear issue

### DIFF
--- a/dellemc-license/templates/dellemc-license-app-configmap.yaml
+++ b/dellemc-license/templates/dellemc-license-app-configmap.yaml
@@ -32,7 +32,6 @@ data:
        - description: "license is expiring or expired"
          name: ExpiringLicense
          issueCategory: Auto
-         defaultAutoClearTimeOut: 720
          matchOnList:
           - matchon:
             - label: SymptomID
@@ -40,6 +39,9 @@ data:
           - matchon:
             - label: SymptomID
               value: DECKS-LIC-1006
+          - matchon:
+            - label: SymptomID
+              value: DECKS-LIC-1002
          notifiers:
               - {{.Values.product}}-supportassist-ese
     eventRemedies: |-


### PR DESCRIPTION
## Purpose
[OBSDEF-5008](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5008)
- Remove autoclear timeout 
- Add DECKS-LIC-1002 normal event to clear the expiring licensing issue.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
```
└─ $ ▶  helm upgrade objs-lic ./dellemc-license --reuse-values --set product=objectscale

└─ $ ▶  kubectl get cm dellemc-objectscale-license-app-config  -o yaml
apiVersion: v1
data:
  eventRemedies: |-
    symptoms:
      - symptomid: DECKS-LIC-1005
        description: Dell EMC subscription license expired for product objectscale
        remedies:
          - Check the end date of the objectscale license
          - Visit the Dell EMC Software Licensing Center (SLC) to
            renew/extend the objectscale license.
          - Contact your Dell EMC sales representative to
            renew/extend the objectscale license
      - symptomid: DECKS-LIC-1006
        description: Dell EMC subscription license for product objectscale is about to expire
        remedies:
          - Check the end date of the license
          - Visit the Dell EMC Software Licensing Center (SLC) to
            renew/extend the objectscale license.
          - Contact your Dell EMC sales representative to
            renew/extend the objectscale license
      - symptomid: DECKS-LIC-1008
        description: Invalid Dell EMC license
        remedies:
          - Verify the objectscale license was obtained from the
            Dell EMC Software Licensing Center
          - Verify the objectscale license was not modified prior to applying it to
            the cluster
          - Verify the PRODUCTSHORTNAME is defined in the objectscale license
          - Verify the subscription dates for licensed features are still valid (not expired)
      - symptomid: DECKS-LIC-1011
        description: License features no longer being tracked
        remedies:
          - Verify the objectscale license is correct and the feature was intended to
            be removed.
  eventRules: "issueRules:\n - description: \"license is invalid\"\n   name: InvalidLicense
    \n   issueCategory: Auto\n   matchOnList:\n    - matchon:\n      - label: SymptomID\n
    \       value: DECKS-LIC-1008\n    - matchon:\n      - label: SymptomID\n        value:
    DECKS-LIC-1002\n   notifiers:\n        - objectscale-supportassist-ese\n - description:
    \"license is expiring or expired\"\n   name: ExpiringLicense\n   issueCategory:
    Auto\n   matchOnList:\n    - matchon:\n      - label: SymptomID\n        value:
    DECKS-LIC-1005\n    - matchon:\n      - label: SymptomID\n        value: DECKS-LIC-1006\n
    \   - matchon:\n      - label: SymptomID\n        value: DECKS-LIC-1002\n   notifiers:\n
    \       - objectscale-supportassist-ese"
  healthChecks: ""
```

