### PR TITLE
[OBSDEF-3902, OBSDEF-5270] Add ConfigMaps for resourcesvc and objectsvc

### DIFF
--- a/ecs-cluster/templates/svc-configs.yaml
+++ b/ecs-cluster/templates/svc-configs.yaml
@@ -18,7 +18,7 @@ data:
 {{ ($.Files.Glob (print "svc-configs/" $svc "/*")).AsConfig | indent 2 }}
 {{- end }}
 
-{{- range $i, $svc := list "rep" }}
+{{- range $i, $svc := list "objectsvc" "rep" "resource" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/ecs-cluster/tests/svc_log4j2_test.yaml
+++ b/ecs-cluster/tests/svc_log4j2_test.yaml
@@ -19,7 +19,7 @@ tests:
       global.monitoring.enabled: false
     asserts:
       - hasDocuments:
-          count: 18
+          count: 20
 
       - equal:
           path: metadata.name

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -268,6 +268,10 @@ objectsvc:
     # tag: stable
     # pullPolicy: IfNotPresent
 
+  # Elements to add to the service's ConfigMap. This is a map of string -> string
+  # for ConfigMap data entries. Values may be multiline strings.
+  extraConfig: {}
+
 # The ECS Object Notification Service configuration specification
 ons:
 
@@ -387,6 +391,10 @@ resource:
     repository: resource-service
     # tag: stable
     # pullPolicy: IfNotPresent
+
+  # Elements to add to the service's ConfigMap. This is a map of string -> string
+  # for ConfigMap data entries. Values may be multiline strings.
+  extraConfig: {}
 
 # The ECS control configuration specification
 # This container image is used in "Micro" performance profile instances


### PR DESCRIPTION
## Purpose
[OBSDEF-3902](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-3902)
[OBSDEF-5270](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5270)

This PR adds service-specific ConfigMaps for objectsvc and resourcesvc to allow setting properties through injected property files.

Related PR for the flex-operator: https://eos2git.cec.lab.emc.com/ECS/ecs-flex-operator/pull/287

## PR checklist
- [x] make test passed
- [ ] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing

Test run with corresponding flex-operator change: https://asd-ecs-jenkins.isus.emc.com/jenkins/job/ecs-flex-automation-custom-runner/2453/
