### PR TITLE
OBSDEF-5349 - Automate setting versions in graphql values charts

### DIFF
--- a/objectscale-graphql/values.yaml
+++ b/objectscale-graphql/values.yaml
@@ -1,5 +1,5 @@
 ---
-# Default values for ecs-flex.
+# Default values for objectscale-graphql.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -13,30 +13,30 @@ global:
   # "Atlantic" - Project Atlantic Bare-Metal Kubernetes platform
   # "Default" - All others
   platform: Default
-
+  #
   # Name of a Kubernetes secret with Docker credentials for the private registry
   # registrySecret: ecs-flex-registry
 
   # The private docker registry hosting containers for ECS Flex
   registry: emccorp
-
+  #
   # Default: true == Watch ALL namespaces
   watchAllNamespaces: true
-
+  #
   # storageClassName  - set default storageClassName for objectscale-manager/graphql
-
+#
 # This is the list of available objectstore versions to graphql for UI to configure the store.
 objectStoreAvailableVersions:
   - 0.65.0
-
+#
 # The default docker tag and pull policy for objectscale-graphql services
 tag: 0.65.0
 pullPolicy: IfNotPresent
-
+#
 # This will create the graphql container with the debug image. debug image will always be {{image.repository}}-debug
 # also, this will expose port 40000 as debug port for debugging the application remotely in the cluster itself
 debug: false
-
+#
 image:
   repository: ecs-flex-graphql
   # tag: stable
@@ -46,12 +46,12 @@ port: 8080
 serviceName: objectscale-graphql
 service:
   type: ClusterIP
-
+#
 decks:
   licenseChartVersion: "2.0.65"
   supportAssistChartVersion: "2.0.65"
   srsGatewayChartVersion: "1.2.0"
-
+#
 logReceiver:
   # The type of log receiver that ECS Flex will use to consolidate logs. Valid
   # are: "Syslog" and "Elasticsearch".  When using a "Syslog" receiver, you can
@@ -85,9 +85,9 @@ fluentbitAgent:
     repository: fluent-bit
     tag: 0.28.0
     # pullPolicy: IfNotPresent
-
+#
 helmController:
   enabled: true
-
+#
 # Release name of objectscale-manager (configuration parameter for objectstore).
 managerReleaseName:


### PR DESCRIPTION
## Purpose
[OBSDEF-5349](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5349)
- Added new "graphqlver" make targe to automate setting objectstore and decks charts for graphql
- This new target will be called during `make release`
- eliminates having to hand-edit values.yaml for release builds
- Fixed up yqcheck to use Makefile `ifneq` statements
- Added extra # comments in `objectscale-graphql/values.yaml` is because `yq` removes blank lines.

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
### new make graphqlver target:
```
└─ $ ▶  make graphqlver PACKAGE_VERSION=0.66
yq e '(.objectStoreAvailableVersions[0] = "0.66.0") | (.decks.licenseChartVersion = "2.0.66") | (.decks.supportAssistChartVersion = "2.0.66") ' -i objectscale-graphql/values.yaml
sed -i '1s/^/---\n/' objectscale-graphql/values.yaml
yamllint -c .yamllint.yml objectscale-graphql/values.yaml
epavkovi @ ubuntu ~/src/emcecs/charts (feature-OBSDEF-5349-auto-graphql-ver)
└─ $ ▶  git diff
diff --git a/objectscale-graphql/values.yaml b/objectscale-graphql/values.yaml
index 9132345..526b934 100644
--- a/objectscale-graphql/values.yaml
+++ b/objectscale-graphql/values.yaml
@@ -27,7 +27,7 @@ global:
 #
 # This is the list of available objectstore versions to graphql for UI to configure the store.
 objectStoreAvailableVersions:
-  - 0.65.0
+  - 0.66.0
 #
 # The default docker tag and pull policy for objectscale-graphql services
 tag: 0.65.0
@@ -48,8 +48,8 @@ service:
   type: ClusterIP
 #
 decks:
-  licenseChartVersion: "2.0.65"
-  supportAssistChartVersion: "2.0.65"
+  licenseChartVersion: "2.0.66"
+  supportAssistChartVersion: "2.0.66"
   srsGatewayChartVersion: "1.2.0"
 #
 logReceiver:
@@ -60,7 +60,6 @@ logReceiver:
   # provide connectivity details in the "logReceiver" configuration block below.
   #
   type:
-
   # User login will be used by fluentd to connect to the elastic search.
   # user: elastic
 
@@ -78,7 +77,6 @@ logReceiver:
   #
   # Port to use for customer provided Syslog or Elasticsearch receiver
   # port: 514
-
 # The log agent configuration for log collection of Manager components
 fluentbitAgent:
   image:
```
