### PR TITLE
[MONITORING-1064][MONITORING-1065] Fixed permissions for rsyslog and influxdb operators

### DIFF
--- a/influxdb-operator/templates/role.yaml
+++ b/influxdb-operator/templates/role.yaml
@@ -13,6 +13,7 @@ rules:
   - apps
   resources:
   - statefulsets
+  - statefulsets/finalizers
   verbs:
   - create
   - delete
@@ -37,6 +38,7 @@ rules:
   - db.ecs.dellemc.com
   resources:
   - influxdbs
+  - influxdbs/finalizers
   verbs:
   - create
   - delete

--- a/statefuldaemonset-operator/templates/role.yaml
+++ b/statefuldaemonset-operator/templates/role.yaml
@@ -13,6 +13,7 @@ rules:
   - apps
   resources:
   - statefulsets
+  - statefulsets/finalizers
   verbs:
   - create
   - delete
@@ -37,6 +38,7 @@ rules:
   - stateful.ecs.dellemc.com
   resources:
   - statefuldaemonsets
+  - statefuldaemonsets/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Purpose
[MONITORING-1064](https://asdjira.isus.emc.com:8443/browse/MONITORING-1064)
[MONITORING-1065](https://asdjira.isus.emc.com:8443/browse/MONITORING-1065)
Added permissions for statefuldaemonset and influxdb operators to fix deployment of rsyslog and InfluxDB on Openshift.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
vsphere: https://asd-ecs-jenkins.isus.emc.com/jenkins/job/ecs-flex-automation-custom-runner/2506/
atlantic: https://asd-ecs-jenkins.isus.emc.com/jenkins/job/ecs-flex-automation-custom-runner/2499/robot/report/log.html
