### PR TITLE
[OBSDEF-5227] - Remove srs test in dkstestapp and add support assist test in decks testapp and dks testapp

### DIFF
--- a/decks/templates/test/test-app.yaml
+++ b/decks/templates/test/test-app.yaml
@@ -35,12 +35,6 @@ spec:
       value: {{ .Values.global.registrySecret }}
     - name: DECKS_NAMESPACE
       value: "{{ .Release.Namespace}}"
-    - name: SRS_TEST_GATEWAY_HOSTNAME
-      value: {{ .Values.helmTestConfig.srsGateway.hostname }}
-    - name: SRS_TEST_GATEWAY_PORT
-      value: "{{ .Values.helmTestConfig.srsGateway.port }}"
-    - name: SRS_TEST_GATEWAY_LOGIN
-      value: {{ .Values.helmTestConfig.srsGateway.login }}
     - name: GLOBAL_IMAGE_TAG
       value: {{ .Values.tag }}
   restartPolicy: Never

--- a/decks/templates/test/test-app.yaml
+++ b/decks/templates/test/test-app.yaml
@@ -35,7 +35,7 @@ spec:
       value: {{ .Values.global.registrySecret }}
     - name: DECKS_NAMESPACE
       value: "{{ .Release.Namespace}}"
-    - name: GLOBAL_IMAGE_TAG
-      value: {{ .Values.tag }}
+    - name: START_TIME
+      value: "{{ now | date "2006-01-02T15:04:05Z07:00" }}"
   restartPolicy: Never
 {{- end}}

--- a/decks/templates/testapp-rbac.yaml
+++ b/decks/templates/testapp-rbac.yaml
@@ -53,6 +53,14 @@ rules:
   resources:
   - clusterroles
   - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - app.k8s.io
+  resources:
+  - "*"
   verbs:
   - "*"
 - apiGroups:
@@ -70,6 +78,7 @@ rules:
   - deployments
   - replicasets
   - serviceaccounts
+  - persistentvolumeclaims
   verbs:
   - "*"
 - apiGroups:

--- a/dks-testapp/templates/app-configmap.yaml
+++ b/dks-testapp/templates/app-configmap.yaml
@@ -9,7 +9,7 @@ data:
             - field: {{ .Values.application.eventRules.field }}
               value: {{ .Values.application.eventRules.fieldValue }}
           notifiers:
-            - supportassist-{{ .Values.supportassist.productName }}
+            - {{ .Values.supportassist.productName }}-supportassist-ese
     healthChecks:  |-
     eventRemedies:  |-
       symptoms:

--- a/dks-testapp/templates/app-configmap.yaml
+++ b/dks-testapp/templates/app-configmap.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 data:
     eventRules:  |-
       rules:
-        - description: "send srs events"
+        - description: "send ese events"
           matchon:
             - label: {{ .Values.application.eventRules.label }}
               value: {{ .Values.application.eventRules.labelValue }}
             - field: {{ .Values.application.eventRules.field }}
               value: {{ .Values.application.eventRules.fieldValue }}
           notifiers:
-            - {{ .Values.srsGateway.name }}-srs
+            - supportassist-{{ .Values.supportassist.productName }}
     healthChecks:  |-
     eventRemedies:  |-
       symptoms:

--- a/dks-testapp/templates/event-configmap.yaml
+++ b/dks-testapp/templates/event-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.application.testAppName }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 data:
 {{- if gt .Values.application.event.totalEvents 10.0 }}
   TEST_EVENTS_COUNT: "10"

--- a/dks-testapp/templates/test/test-app.yaml
+++ b/dks-testapp/templates/test/test-app.yaml
@@ -32,7 +32,11 @@ spec:
     - name: SUPPORTASSIST_PRODUCT_NAME
       value: {{ .Values.supportassist.productName }}
     - name: SUPPORTASSIST_NAMESPACE
+{{- if .Values.supportassist.namespace}}
+      value: {{ .Values.supportassist.namespace }}
+{{- else}}
       value: {{ .Release.Namespace }}
+{{- end}}
     - name: REGISTRY_SECRET
       value: {{ .Values.global.registrySecret }}
     envFrom:

--- a/dks-testapp/templates/test/test-app.yaml
+++ b/dks-testapp/templates/test/test-app.yaml
@@ -30,10 +30,10 @@ spec:
       value: {{ .Values.application.testAppName }}
     - name: TEST_APP_NAMESPACE
       value: {{ .Release.Namespace }}
-    - name: SRS_GATEWAY_NAME
-      value: {{ .Values.srsGateway.name }}
-    - name: SRS_GATEWAY_NAMESPACE
-      value: {{ .Values.srsGateway.namespace }}
+    - name: SUPPORTASSIST_PRODUCT_NAME
+      value: {{ .Values.supportassist.productName }}
+    - name: SUPPORTASSIST_NAMESPACE
+      value: {{ .Values.supportassist.namespace }}
     - name: REGISTRY_SECRET
       value: {{ .Values.global.registrySecret }}
     envFrom:

--- a/dks-testapp/templates/test/test-app.yaml
+++ b/dks-testapp/templates/test/test-app.yaml
@@ -25,7 +25,6 @@ spec:
     command:
     - dks-testapp
     env:
-    env:
     - name: TEST_APP_NAME
       value: {{ .Values.application.testAppName }}
     - name: TEST_APP_NAMESPACE
@@ -33,7 +32,7 @@ spec:
     - name: SUPPORTASSIST_PRODUCT_NAME
       value: {{ .Values.supportassist.productName }}
     - name: SUPPORTASSIST_NAMESPACE
-      value: {{ .Values.supportassist.namespace }}
+      value: {{ .Release.Namespace }}
     - name: REGISTRY_SECRET
       value: {{ .Values.global.registrySecret }}
     envFrom:

--- a/dks-testapp/templates/test/test-app.yaml
+++ b/dks-testapp/templates/test/test-app.yaml
@@ -25,6 +25,8 @@ spec:
     command:
     - dks-testapp
     env:
+    - name: START_TIME
+      value: "{{ now | date "2006-01-02T15:04:05Z07:00" }}"
     - name: TEST_APP_NAME
       value: {{ .Values.application.testAppName }}
     - name: TEST_APP_NAMESPACE

--- a/dks-testapp/values.yaml
+++ b/dks-testapp/values.yaml
@@ -31,16 +31,16 @@ application:
   event:
     totalEvents: 5
     type: "Critical"
-    label: "srs-event"
+    label: "ese-event"
     labelValue: "true"
-    reason: "srs-test"
-    message: "this is an SRS test event"
+    reason: "ese-test"
+    message: "this is an ESE test event"
 
   # Default event rules will create a configmap for the application event routing rule.
   # The user needs to change according to their requirement. The rule is that if an event matches with
   # the defined rule (label + field), it will route the event to SRS notifier.
   eventRules:
-    label: "srs-event"
+    label: "ese-event"
     labelValue: "true"
     field: "type"
     fieldValue: "Critical"
@@ -49,6 +49,6 @@ application:
 
 # The following specifies the SRSGateway to be tested. The name and namespace must be the name
 # of srsGateway custom resource.
-srsGateway:
-  name: "objectscale"
+supportassist:
+  productName: "objectscale"
   namespace: "default"

--- a/dks-testapp/values.yaml
+++ b/dks-testapp/values.yaml
@@ -38,17 +38,16 @@ application:
 
   # Default event rules will create a configmap for the application event routing rule.
   # The user needs to change according to their requirement. The rule is that if an event matches with
-  # the defined rule (label + field), it will route the event to SRS notifier.
+  # the defined rule (label + field), it will route the event to ESE notifier.
   eventRules:
     label: "ese-event"
     labelValue: "true"
     field: "type"
     fieldValue: "Critical"
-    # notifier will be derived from srsGateway
-    # the format of notifier <srsGateway.name>-<srsGateway.namespace>-srs
+    # notifier will be derived from supportassist
 
-# The following specifies the SRSGateway to be tested. The name and namespace must be the name
-# of srsGateway custom resource.
+# The following specifies the supportassist to be tested. The name and namespace must be the product name
+# of supportassist custom resource.
 supportassist:
   productName: "objectscale"
-  namespace: "default"
+  # namespace: "default"


### PR DESCRIPTION
## Purpose
[OBSDEF-5227](https://jira.cec.lab.emc.com/browse/OBSDEF-5227)
changes in dks-testapp chart to remove srs test

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [x] helm test <release_name> passed

## Testing
helm test decks pod logs:
```
Error during unmarshalling custom config open /etc/config/logger-config.yaml: no such file or directory. Using default config
time="2021-03-11T08:27:57Z" level=info msg="Starting decks-testapp version: 2.0.68-185.4ff59cb" func="main.main() " file="main.go:58"
time="2021-03-11T08:27:58Z" level=info msg="DECKS POD is ready" func="main.main() " file="main.go:101"
time="2021-03-11T08:27:58Z" level=debug msg="orig name: dellemc-unisphere-license sanitized name: dellemc-unisphere-license" func="secrets.sanitize() " file="secrets_controller.go:509"
time="2021-03-11T08:27:58Z" level=info msg="test-unisphere-lic secret is created, kubectl output: secret/test-unisphere-lic created\n" func="testapp.verifyLicense() " file="testapp.go:567"
time="2021-03-11T08:27:59Z" level=error msg="Get License resource: dellemc-unisphere-license in namespace default failed with err: licenses.decks.ecs.dellemc.com \"dellemc-unisphere-license\" not found" func="testapp.checkIfLicenseResourceCreated() " file="testapp.go:592"
time="2021-03-11T08:28:00Z" level=error msg="Get License resource: dellemc-unisphere-license in namespace default failed with err: licenses.decks.ecs.dellemc.com \"dellemc-unisphere-license\" not found" func="testapp.checkIfLicenseResourceCreated() " file="testapp.go:592"
time="2021-03-11T08:28:01Z" level=error msg="Get License resource: dellemc-unisphere-license in namespace default failed with err: licenses.decks.ecs.dellemc.com \"dellemc-unisphere-license\" not found" func="testapp.checkIfLicenseResourceCreated() " file="testapp.go:592"
time="2021-03-11T08:28:02Z" level=error msg="Get License resource: dellemc-unisphere-license in namespace default failed with err: licenses.decks.ecs.dellemc.com \"dellemc-unisphere-license\" not found" func="testapp.checkIfLicenseResourceCreated() " file="testapp.go:592"
time="2021-03-11T08:28:03Z" level=info msg="test-unisphere-lic secret is deleted, kubectl output: secret \"test-unisphere-lic\" deleted\n" func="testapp.deleteLicenseSecret() " file="testapp.go:614"
time="2021-03-11T08:28:04Z" level=info msg="test-unisphere-lic secret is created, kubectl output: secret/test-unisphere-lic created\n" func="testapp.verifyLicense() " file="testapp.go:567"
time="2021-03-11T08:28:05Z" level=info msg="License: dellemc-unisphere-license in default namespace  created" func="testapp.checkIfLicenseResourceCreated() " file="testapp.go:595"
time="2021-03-11T08:28:05Z" level=info msg="License gets created with valid license secrets" func="main.main() " file="main.go:111"
time="2021-03-11T08:28:05Z" level=info msg="env REGISTRY_SECRET: ecs-flex-registry" func="testapp.CreateSampleServicePod() " file="testapp.go:155"
time="2021-03-11T08:28:05Z" level=info msg="env REGISTRY_NAME: emccorp" func="testapp.CreateSampleServicePod() " file="testapp.go:165"
time="2021-03-11T08:28:06Z" level=info msg="service pod helm-test-svc-pod is installed in default namespace" func="testapp.CreateSampleServicePod() " file="testapp.go:182"
time="2021-03-11T08:28:06Z" level=info msg="sample service pod: helm-test-svc-pod - default  is created" func="main.main() " file="main.go:121"
time="2021-03-11T08:28:06Z" level=info msg="env REGISTRY_SECRET: ecs-flex-registry" func="testapp.CreateSampleSupportAssist() " file="testapp.go:220"
time="2021-03-11T08:28:06Z" level=info msg="env REGISTRY_NAME: emccorp" func="testapp.CreateSampleSupportAssist() " file="testapp.go:230"
time="2021-03-11T08:28:07Z" level=info msg="Support Assist helm-test-supportassist is installed in default namespace" func="testapp.CreateSampleSupportAssist() " file="testapp.go:253"
time="2021-03-11T08:28:07Z" level=info msg="sample SupportAssist: helm-test-supportassist - default  is created" func="main.main() " file="main.go:132"
time="2021-03-11T08:30:29Z" level=info msg="POD supportassist-base-648d84f6c9-dcdkx is ready" func="testapp.CheckSampleSupportAssistPods() " file="testapp.go:320"
time="2021-03-11T08:30:30Z" level=info msg="POD supportassist-base-notifier-7d858df864-lp4wr is ready" func="testapp.CheckSampleSupportAssistPods() " file="testapp.go:320"
time="2021-03-11T08:30:31Z" level=info msg="POD supportassist-base-ese-callback-799b4b867b-x2sdc is ready" func="testapp.CheckSampleSupportAssistPods() " file="testapp.go:320"
time="2021-03-11T08:30:31Z" level=info msg="all related pods for SupportAssist: helm-test-supportassist are ready" func="main.main() " file="main.go:152"
...
...
time="2021-03-11T08:34:10Z" level=info msg="Support Assist RemoteAccess Service: base-remote-service is ready" func="testapp.VerifySupportAssist() " file="testapp.go:376"
time="2021-03-11T08:34:10Z" level=info msg="Support Assist Notifier Service: supportassist-base-notifier is ready" func="testapp.VerifySupportAssist() " file="testapp.go:384"
time="2021-03-11T08:34:10Z" level=info msg="Support Assist callback Service: supportassist-base-ese-callback is ready" func="testapp.VerifySupportAssist() " file="testapp.go:392"
time="2021-03-11T08:34:10Z" level=info msg="get user and password from service pod credential secret" func="testapp.VerifySupportAssist() " file="testapp.go:401"
time="2021-03-11T08:34:10Z" level=info msg="connected to remote server: 172.17.100.2:22" func="testapp.VerifySSHRemoteAccess() " file="testapp.go:511"
time="2021-03-11T08:34:10Z" level=info msg="Support Assist RemoteAccess SSH is successful for 172.17.100.2" func="testapp.VerifySupportAssist() " file="testapp.go:409"
time="2021-03-11T08:34:10Z" level=info msg="All tests are successful" func="testapp.VerifySupportAssist() " file="testapp.go:411"
time="2021-03-11T08:34:10Z" level=info msg="sample SupportAssist helm-test-supportassist passed verification" func="main.main() " file="main.go:162"
time="2021-03-11T08:34:10Z" level=info msg="test-unisphere-lic secret is deleted, kubectl output: secret \"test-unisphere-lic\" deleted\n" func="testapp.deleteLicenseSecret() " file="testapp.go:614"
time="2021-03-11T08:34:11Z" level=info msg="sample support assist helm-test-supportassist is deleted, kubectl output: release \"helm-test-supportassist\" uninstalled\n" func="testapp.DeleteSampleSupportAssist() " file="testapp.go:298"
time="2021-03-11T08:34:11Z" level=info msg="sample service pod helm-test-svc-pod is deleted, kubectl output: release \"helm-test-svc-pod\" uninstalled\n" func="testapp.DeleteSampleServicePod() " file="testapp.go:195"
time="2021-03-11T08:34:11Z" level=info msg="All tests completed successfully" func="main.main() " file="main.go:179"
```

helm test dks pod log:
```
Error during unmarshalling custom config open /etc/config/logger-config.yaml: no such file or directory. Using default config
time="2021-03-15T06:47:38Z" level=info msg="Starting dks-testapp version: 2.68.2-201.7332c38" func="main.main() " file="main.go:71"
time="2021-03-15T06:47:39Z" level=info msg="KAHM POD: kahm-0 in namespace: default is ready" func="main.main() " file="main.go:123"
time="2021-03-15T06:47:40Z" level=info msg="DECKS POD: decks-85f9df5dc8-f2l77 in namespace: default is ready" func="main.main() " file="main.go:137"
time="2021-03-15T06:47:41Z" level=info msg="ESENotifier: supportassist-objectscale in namespace: default is connected" func="main.main() " file="main.go:164"
time="2021-03-15T06:47:41Z" level=info msg="TestApplication: dks-testapp in namespace: default establish the Event rules in the secondary resource configmap: dks-testapp-app-config" func="main.main() " file="main.go:171"
2021/03/15 06:47:46 appName is missing in Basic event
2021/03/15 06:47:46 appName is missing in Basic event
2021/03/15 06:47:46 appName is missing in Basic event
2021/03/15 06:47:46 appName is missing in Basic event
2021/03/15 06:47:46 appName is missing in Basic event
time="2021-03-15T06:47:46Z" level=info msg="Total: 5 events generated with type: Critical reason: ese-test and test label: ese-event=true" func="main.generateEvents() " file="main.go:301"
time="2021-03-15T06:47:48Z" level=info msg="ESENotifier: supportassist-objectscale in in namespace: default received all the generated events" func="main.main() " file="main.go:201"
time="2021-03-15T06:47:48Z" level=info msg="REST POST URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events" func="util.POSTEvent() " file="restapi.go:299"
time="2021-03-15T06:47:49Z" level=info msg="We expected an error for missing params error was: HTTP POST req failed with status: 400 Bad Request" func="util.VerifyRESTAPIs() " file="restapi.go:128"
time="2021-03-15T06:47:49Z" level=info msg="REST POST URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events" func="util.POSTEvent() " file="restapi.go:299"
time="2021-03-15T06:47:49Z" level=info msg="POST for the event with id: dks-testapp-default-appevent-dhjnp succeed" func="util.VerifyRESTAPIs() " file="restapi.go:144"
time="2021-03-15T06:47:51Z" level=debug msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/dks-testapp-default-appevent-dhjnp" func="util.GETEvent() " file="restapi.go:398"
time="2021-03-15T06:47:51Z" level=info msg="GET for the event with id: dks-testapp-default-appevent-dhjnp succeed" func="util.VerifyRESTAPIs() " file="restapi.go:166"
time="2021-03-15T06:47:51Z" level=debug msg="REST PATCH URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/dks-testapp-default-appevent-dhjnp" func="util.PATCH() " file="restapi.go:271"
time="2021-03-15T06:47:51Z" level=info msg="event: dks-testapp-default-appevent-dhjnp is updated with ACK flag" func="util.VerifyRESTAPIs() " file="restapi.go:174"
time="2021-03-15T06:47:53Z" level=debug msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/dks-testapp-default-appevent-dhjnp" func="util.GETEvent() " file="restapi.go:398"
time="2021-03-15T06:47:53Z" level=info msg="event: dks-testapp-default-appevent-dhjnp is retrieved with ACK flag" func="util.VerifyRESTAPIs() " file="restapi.go:187"
time="2021-03-15T06:47:53Z" level=info msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events" func="util.GETAllEvents() " file="restapi.go:466"
time="2021-03-15T06:47:54Z" level=info msg="total retrieved events: 1282 for all applications" func="util.VerifyRESTAPIs() " file="restapi.go:197"
time="2021-03-15T06:47:54Z" level=info msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events?appname=dks-testapp&namespace=default" func="util.GETAllEvents() " file="restapi.go:466"
time="2021-03-15T06:47:54Z" level=info msg="total retrieved events: 41 for the application: dks-testapp in namespace: default" func="util.VerifyRESTAPIs() " file="restapi.go:208"
time="2021-03-15T06:47:54Z" level=info msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events?appname=dks-testapp" func="util.GETAllEvents() " file="restapi.go:466"
time="2021-03-15T06:47:54Z" level=info msg="total retrieved events: 41 for the application: dks-testapp in namespace: default" func="util.VerifyRESTAPIs() " file="restapi.go:216"
time="2021-03-15T06:47:54Z" level=info msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events?appname=dks-testapp&namespace=default&acknowledged=true" func="util.GETAllEvents() " file="restapi.go:466"
time="2021-03-15T06:47:54Z" level=info msg="total retrieved ACKed events: 1 for the application: dks-testapp in namespace: default" func="util.VerifyRESTAPIs() " file="restapi.go:227"
time="2021-03-15T06:47:54Z" level=info msg="REST GET URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events?appname=dks-testapp&namespace=defaultacknowledged=false" func="util.GETAllEvents() " file="restapi.go:466"
time="2021-03-15T06:47:54Z" level=info msg="total retrieved no ACKed events: 0 for the application: dks-testapp in namespace: default" func="util.VerifyRESTAPIs() " file="restapi.go:235"
time="2021-03-15T06:47:54Z" level=info msg="REST POST URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/bulkupdate" func="util.POSTBulkUpdate() " file="restapi.go:333"
time="2021-03-15T06:47:54Z" level=info msg="total events: 41 total updated: 40 for the application: dks-testapp in namespace: default" func="util.VerifyRESTAPIs() " file="restapi.go:243"
time="2021-03-15T06:47:54Z" level=info msg="REST POST URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/bulkupdate" func="util.POSTBulkUpdate() " file="restapi.go:333"
time="2021-03-15T06:47:54Z" level=info msg="total events: 41 total updated: 41 for the application: dks-testapp in namespace: default" func="util.VerifyRESTAPIs() " file="restapi.go:249"
time="2021-03-15T06:47:54Z" level=info msg="REST POST URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/grafana" func="util.POSTEvent() " file="restapi.go:299"
time="2021-03-15T06:47:54Z" level=info msg="POST for the grafana event with id: dks-testapp-default-appevent-z4c8g succeed" func="util.VerifyRESTAPIs() " file="restapi.go:258"
time="2021-03-15T06:47:54Z" level=info msg="REST POST URL: http://kahm-restapi.default.svc.cluster.local:17999/v1/api/events/grafana" func="util.POSTEventWithBadSecrets() " file="restapi.go:372"
time="2021-03-15T06:47:54Z" level=info msg="POST for the grafana event with bad credentials gets Unauthorized" func="util.VerifyRESTAPIs() " file="restapi.go:265"
time="2021-03-15T06:47:54Z" level=info msg="KAHM REST interface is tested successfully" func="main.main() " file="main.go:209"
time="2021-03-15T06:47:54Z" level=info msg="All tests completed successfully" func="main.main() " file="main.go:211"
```