### PR TITLE
[OBSDEF-5672] Fix incorrect indention in configmap

### DIFF
--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -21,9 +21,9 @@ data:
     health: |-
       spec:
         - name: pre-update
-            container: {{.Values.global.registry}}/objectscale-manager-pre-update:{{.Values.tag}}
-            schedule: "*/30 * * * *"
-            timelimit: "5m"
+          container: {{.Values.global.registry}}/objectscale-manager-pre-update:{{.Values.tag}}
+          schedule: "*/30 * * * *"
+          timelimit: "5m"
     eventRemedies: |-
       symptoms:
         - symptomid: DEOS-MGR-1001


### PR DESCRIPTION
## Purpose
[OBSDEF-5672](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5672)

The indention was incorrect on the health check configuration of the objectscale-manager application configuration configmap for KAHM.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [x] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

