### PR TITLE
[OBSDEF-5672] Add Installer REST credentials to GraphQL deployment

### DIFF
--- a/ecs-cluster/templates/objectstore-app-configmap.yaml
+++ b/ecs-cluster/templates/objectstore-app-configmap.yaml
@@ -27,14 +27,14 @@ data:
 {{ end }}
     health: |-
       spec:
-        - name: objectstore-healthcheck
+        - name: healthcheck
           container: {{.Values.global.registry}}/{{.Values.healthChecks.connectivity.image.repository}}:{{default .Values.tag .Values.healthChecks.connectivity.image.tag}}
           serviceaccount: {{.Release.Name}}-healthchecks
           schedule: "0 */6 * * *"
           timelimit: "5m"
           args:
             - all
-        - name: objectstore-pre-update
+        - name: pre-update
           container: {{.Values.global.registry}}/{{.Values.healthChecks.preUpdate.image.repository}}:{{default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
           serviceaccount: {{.Release.Name}}-healthchecks
           schedule: "*/30 * * * *"

--- a/helm-controller/templates/service.yaml
+++ b/helm-controller/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: objectscale-manager
     app.kubernetes.io/component: objectscale-install-controller
-    helm.sh/chart: {{ .Chart.Name }}- {{ .Chart.Version | replace "+" "_" }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/helm-controller/templates/service.yaml
+++ b/helm-controller/templates/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-installer
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: objectscale-manager
     app.kubernetes.io/component: objectscale-install-controller
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    helm.sh/chart: {{ .Chart.Name }}- {{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/objectscale-graphql/templates/graphql-deployment.yaml
+++ b/objectscale-graphql/templates/graphql-deployment.yaml
@@ -94,6 +94,13 @@ spec:
 {{- else }}
           value: stdout
 {{- end }}
+        - name: HELM_CONTROLLER_ENDPOINT
+          value: {{ .Release.Name }}-installer
+        - name: HELM_CONTROLLER_REST_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-rest-credentials
+              key: credentials
 {{- if .Values.withPlayground }}
         args:
           - "-P"


### PR DESCRIPTION
## Purpose
[OBSDEF-5672](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5672)

This change is needed to support one-click install procedures, in which the GraphQL service will retrieve Helm chart information from the installer via REST

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

