### PR TITLE
[OBSDEF-5766] - Allow docker registry and credentials to be set for ObjectScale on vSphere7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ PACKAGE_NAME        := objectscale-charts-package.tgz
 NAMESPACE            = dellemc-objectscale-system
 TEMP_PACKAGE        := temp_package
 SERVICE_ID           = objectscale
-REGISTRY             = objectscale
-DECKS_REGISTRY       = objectscale
-KAHM_REGISTRY        = objectscale
+REGISTRY             = REGISTRYTEMPLATE
+DECKS_REGISTRY       = REGISTRYTEMPLATE
+KAHM_REGISTRY        = REGISTRYTEMPLATE
+REGISTRYSECRET       = vsphere-docker-secret
 STORAGECLASSNAME     = dellemc-${SERVICE_ID}-highly-available
 STORAGECLASSNAME_VSAN_SNA     = dellemc-${SERVICE_ID}-vsan-sna-thick
 
@@ -181,6 +182,8 @@ create-manager-app: create-temp-package
 	--set global.platform=VMware \
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
 	--set global.registry=${REGISTRY} \
+	--set hooks.registry=${REGISTRY} \
+	--set global.registrySecret=${REGISTRYSECRET} \
 	--set global.storageClassName=${STORAGECLASSNAME} \
 	--set global.monitoring_registry=${REGISTRY} \
 	--set ecs-monitoring.influxdb.persistence.storageClassName=${STORAGECLASSNAME} \
@@ -201,6 +204,7 @@ create-vsphere-templates: create-temp-package
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
     --set graphql.enabled=true \
 	--set global.registry=${REGISTRY} \
+	--set global.registrySecret=${REGISTRYSECRET} \
 	--set global.storageClassName=${STORAGECLASSNAME} ${HELM_UI_ARGS} ${HELM_GRAPHQL_ARGS} ${HELM_INSTALLER_ARGS} \
 	-f objectscale-vsphere/values.yaml >> ${TEMP_PACKAGE}/yaml/${MANAGER_MANIFEST}
 
@@ -211,6 +215,7 @@ create-decks-app: create-temp-package
 	--set global.platform=VMware \
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
 	--set global.registry=${DECKS_REGISTRY} \
+	--set global.registrySecret=${REGISTRYSECRET} \
 	--set decks-support-store.persistentVolume.storageClassName=${STORAGECLASSNAME} \
         ${HELM_DECKS_ARGS} ${HELM_DECKS_SUPPORT_STORE_ARGS} \
 	-f values.yaml > ../${TEMP_PACKAGE}/yaml/decks-app.yaml;
@@ -225,6 +230,7 @@ create-kahm-app: create-temp-package
 	--set global.platform=VMware \
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
 	--set global.registry=${KAHM_REGISTRY} \
+	--set global.registrySecret=${REGISTRYSECRET} \
 	--set storageClassName=${STORAGECLASSNAME} \
         ${HELM_KAHM_ARGS} \
 	-f values.yaml > ../${TEMP_PACKAGE}/yaml/kahm-app.yaml;
@@ -263,6 +269,7 @@ create-manager-manifest-ci: create-temp-package
 	helm template objectscale-manager ./objectscale-manager -n ${NAMESPACE} \
 	--set global.platform=Default --set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
 	--set global.registry=${REGISTRY} \
+	--set global.registrySecret=${REGISTRYSECRET} \
 	--set global.storageClassName=${STORAGECLASSNAME} \
 	--set logReceiver.create=false \
 	-f objectscale-manager/values.yaml >> ${TEMP_PACKAGE}/yaml/${MANAGER_MANIFEST}

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -21,6 +21,8 @@ metadata:
 spec:
 {{- if .Values.global.registrySecret }}
   registrySecret: {{ .Values.global.registrySecret }}
+  imagePullSecrets:
+   - name: {{ .Values.global.registrySecret }}
 {{- end }}
 {{- if .Values.replicas }}
   replicas: {{ .Values.replicas }}

--- a/objectscale-vsphere/templates/vsphere-plugin-deployment.yaml
+++ b/objectscale-vsphere/templates/vsphere-plugin-deployment.yaml
@@ -35,6 +35,10 @@ spec:
         operator: objectscale-operator
         product: objectscale
     spec:
+      {{- if .Values.global.registrySecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/objectscale-vsphere/templates/vsphere-plugin-secrets.yaml
+++ b/objectscale-vsphere/templates/vsphere-plugin-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-docker-secret
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: DOCKERSECRETPLACEHOLDER
+type: kubernetes.io/dockerconfigjson 

--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -65,6 +65,13 @@ sed -i 's/[[:space:]]*$//' temp_package/yaml/${vsphere7_plugin_file}
 ## Template the namespace value
 sed -i "s/$namespace/{{ .service.namespace }}/g" temp_package/yaml/${vsphere7_plugin_file}
 
+## Template registry from supervisor service input
+sed -i -e "s/REGISTRYTEMPLATE/{{ .Values.registryName }}/g" temp_package/yaml/*
+
+## Template docker username and password from supervisor service input
+dockersecret='{{printf "{\\"auths\\": {\\"%s\\": {\\"auth\\": \\"%s\\"}}}" "https:\/\/index.docker.io\/v1\/" (printf "%s:%s" .Values.registryUsername .Values.registryPasswd | b64enc) | b64enc}}'
+sed -i -e "s/DOCKERSECRETPLACEHOLDER/$dockersecret/g" temp_package/yaml/*
+
 ## Template the vsphere service prefix value
 sed -i "s/VSPHERE_SERVICE_PREFIX_VALUE/{{ .service.prefix }}/g" temp_package/yaml/${vsphere7_plugin_file}
 


### PR DESCRIPTION
## Purpose
[OBSDEF-5766](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5766)
Add dark site feature for 0.64.x

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [x] helm upgrade <chart> passed
- [x] helm test <release_name> passed

## Testing
All pods start correctly, currently running into an issue where the namespace does not populate under vsphere UI for objectstore creation.