### PR TITLE
OBSDEF-5726 - Change dellemc-license managed-by in app resource so that managed by correct service

### DIFF
--- a/dellemc-license/templates/dellemc-license-app-configmap.yaml
+++ b/dellemc-license/templates/dellemc-license-app-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
         app.kubernetes.io/name: dellemc-{{.Values.product}}-license
         app.kubernetes.io/version: {{.Values.tag}}
         app.kubernetes.io/instance: {{.Release.Name}}
-        app.kubernetes.io/managed-by: nautilus
+        app.kubernetes.io/managed-by: {{.Release.Service}}
         helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
         release: {{.Release.Name}}
         product: {{.Values.product}}
@@ -18,7 +18,7 @@ data:
     eventRules: |-
       issueRules:
        - description: "license is invalid"
-         name: InvalidLicense 
+         name: InvalidLicense
          issueCategory: Auto
          matchOnList:
           - matchon:

--- a/dellemc-license/templates/dellemc-license-app.yaml
+++ b/dellemc-license/templates/dellemc-license-app.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dellemc-{{.Values.product}}-license
     app.kubernetes.io/version: {{.Values.tag}}
     app.kubernetes.io/instance: {{.Release.Name}}
-    app.kubernetes.io/managed-by: nautilus
+    app.kubernetes.io/managed-by: {{.Release.Service}}
     helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
     product: {{.Values.product}}
     release: {{.Release.Name}}
@@ -32,8 +32,8 @@ spec:
       Dell EMC License
     keywords:
       - "decks"
-      - "srs"
+      - "supportassist"
       - "licensing"
     info:
-      - "Copyright © 2019 Dell Inc. or its subsidiaries. All Rights Reserved."
+      - "Copyright © 2019-2021 Dell Inc. or its subsidiaries. All Rights Reserved."
 {{- end}}


### PR DESCRIPTION
## Purpose
[OBSDEF-5726](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5726)
- Changed app managed-by field to be managed by service it was installed by
- 
## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
### on paige installed and removed license in helm
```
└─ $ ▶  helm install objs-lic ~/src/emcecs/charts/dellemc-license --set-file licensefile=/home/epavkovi/vmshare/OBJS_Echo_Cloud_Perf_20210201.xml --set product=objectscale
NAME: objs-lic
LAST DEPLOYED: Thu Feb 18 22:53:34 2021
NAMESPACE: dellemc-objectscale-domain-c54
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing dellemc-license. This release is capable of
deploying a Dell EMC license secret to create Dell EMC k8s license resource.


Your release is named objs-lic.

To install dellemc-license by using Helm chart, use the helm install command below:

  $ helm install <repository name>/dellemc-license --set-file licensefile=<location of license xml file> --set product=<product name>

For more information on the installation and configuration options, see the
README at https://github.com/EMCECS/charts/tree/master/dellemc-license and the
`values.yaml` file at
https://github.com/EMCECS/charts/blob/master/dellemc-license/values.yaml

└─ $ ▶  helm list | grep lic
objs-lic                           	dellemc-objectscale-domain-c54	1       	2021-02-18 22:53:34.110790795 -0500 EST	deployeddellemc-license-2.0.67    	2.0.67     
epavkovi @ ubuntu ~/src/emcecs/charts (master)
└─ $ ▶  kubectl get app dellemc-objectscale-license 
NAME                          TYPE              VERSION   OWNER   READY   AGE
dellemc-objectscale-license   dellemc-license   2.0.67                    4m26s
epavkovi @ ubuntu ~/src/emcecs/charts (master)
└─ $ ▶  kubectl get licenses.decks.ecs.dellemc.com 
NAME                          AGE
dellemc-objectscale-license   4m32s
epavkovi @ ubuntu ~/src/emcecs/charts (master)
└─ $ ▶  helm delete objs-lic
release "objs-lic" uninstalled
epavkovi @ ubuntu ~/src/emcecs/charts (master)
└─ $ ▶  kubectl get app dellemc-objectscale-license 
Error from server (NotFound): applications.app.k8s.io "dellemc-objectscale-license" not found
epavkovi @ ubuntu ~/src/emcecs/charts (master)
└─ $ ▶  kubectl get app
NAME                                  TYPE                        VERSION   OWNER   READY   AGE
certificate-tes                       objectstore                 0.67.0                    44h
decks                                 decks                       2.0.67                    7d23h
kahm                                  kahm                        2.0.67                    7d23h
logging-injector                      logging-injector            0.67.0                    7d23h
objectscale-manager                   objectscale-manager         0.67.0                    7d23h
pipeline-large-ecdis-dareen           objectstore                 0.67.0                    2d16h
pipeline-vsansna-large-ecen-daredis   objectstore                 0.67.0                    3d16h
prats1-124                            objectstore                 0.67.0                    36h
serviceabilitystore                   objectstore                 0.67.0                    7d22h
supportassist-objectscale             supportassist-objectscale   2.0.67                    38h
```