### PR TITLE
[OBSDEF-1200]add support of bk blockOwnerDeletion parameter

### DIFF
--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -209,6 +209,25 @@ spec:
     version:  {{ .Values.bookkeeper.version }}
     blockOwnerDeletion:  {{ .Values.bookkeeper.blockOwnerDeletion }}
     autoRecovery: {{ .Values.bookkeeper.autoRecovery }}
+    {{- if .Values.bookkeeper.probes }}
+    probes:
+      {{- if .Values.bookkeeper.probes.readiness }}
+      readinessProbe:
+        initialDelaySeconds: {{ .Values.bookkeeper.probes.readiness.initialDelaySeconds | default 20 }}
+        periodSeconds: {{ .Values.bookkeeper.probes.readiness.periodSeconds | default 10 }}
+        failureThreshold: {{ .Values.bookkeeper.probes.readiness.failureThreshold | default 9 }}
+        successThreshold: {{ .Values.bookkeeper.probes.readiness.successThreshold | default 1 }}
+        timeoutSeconds: {{ .Values.bookkeeper.probes.readiness.timeoutSeconds | default 5 }}
+      {{- end }}
+      {{- if .Values.bookkeeper.probes.liveness }}
+      livenessProbe:
+        initialDelaySeconds: {{ .Values.bookkeeper.probes.liveness.initialDelaySeconds | default 60 }}
+        periodSeconds: {{ .Values.bookkeeper.probes.liveness.periodSeconds | default 15 }}
+        failureThreshold: {{ .Values.bookkeeper.probes.liveness.failureThreshold | default 4 }}
+        successThreshold: {{ .Values.bookkeeper.probes.liveness.successThreshold | default 1 }}
+        timeoutSeconds: {{ .Values.bookkeeper.probes.liveness.timeoutSeconds | default 5 }}
+      {{- end }}
+    {{- end }}
     storage:
       ledgerVolumeClaimTemplate:
         accessModes: [ "ReadWriteOnce" ]

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -207,6 +207,7 @@ spec:
         repository: {{ .Values.pravegaRepository }}/bookkeeper
         pullPolicy: {{ with .Values.bookkeeper.image }}{{ .pullPolicy }}{{ end }}
     version:  {{ .Values.bookkeeper.version }}
+    blockOwnerDeletion:  {{ .Values.bookkeeper.blockOwnerDeletion }}
     autoRecovery: {{ .Values.bookkeeper.autoRecovery }}
     storage:
       ledgerVolumeClaimTemplate:

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -161,6 +161,19 @@ bookkeeper:
   version: 0.9.0-2725.77b13981a
   blockOwnerDeletion: false
   autoRecovery: true
+  probes:
+    readiness:
+      initialDelaySeconds: 20
+      periodSeconds: 120
+      failureThreshold: 9
+      successThreshold: 1
+      timeoutSeconds: 45
+    liveness:
+      initialDelaySeconds: 60
+      periodSeconds: 15
+      failureThreshold: 4
+      successThreshold: 1
+      timeoutSeconds: 5
   storage:
     ledger:
       # storageClassName:

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -159,6 +159,7 @@ bookkeeper:
   image:
     pullPolicy: IfNotPresent
   version: 0.9.0-2725.77b13981a
+  blockOwnerDeletion: false
   autoRecovery: true
   storage:
     ledger:


### PR DESCRIPTION
## Purpose
[OBSDEF-1200](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-1200)
add support of bk blockOwnerDeletion parameter

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

