### PR TITLE
[OBSDEF-5307] - Set remote access enabled to false if using direct mode

### DIFF
--- a/supportassist/templates/supportassist-cr.yaml
+++ b/supportassist/templates/supportassist-cr.yaml
@@ -16,7 +16,7 @@ spec:
   systemMode: {{ default "preProd" .Values.systemMode }}
   eventMuted: {{ default false .Values.eventMuted }}
   testDialHome: {{ default false .Values.testDialHome }}
-  {{- if ne .Values.enabled true }}
+  {{- if or (ne .Values.enabled true) (eq .Values.useGateways false) }}
   remoteAccessEnabled: false
   {{- else }}
   remoteAccessEnabled: {{ default false .Values.remoteAccessEnabled }}


### PR DESCRIPTION
## Purpose
[OBSDEF-5307](https://jira.cec.lab.emc.com/browse/OBSDEF-5307)
When we are using direct mode(useGateways=false), we need to set remoteAccessEnabled=false.

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [x] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
support assist cr:
```
  ...
  remoteAccessEnabled: true
  siteID: 11145366
  systemMode: preProd
  testDialHome: true
  useGateways: true
  ...
```
Run `helm upgrade sa supportassist/ --reuse-values --set useGateways=false`
Now support assist cr:
```
  ...
  remoteAccessEnabled: false
  siteID: 11145366
  systemMode: preProd
  testDialHome: true
  useGateways: false
  ...
```