### PR TITLE
[OBSDEF-6119] Enable object store metering service by default

### DIFF
--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -73,8 +73,8 @@ features:
   # Enable Cross Region Replication
   enableCRR: false
 
-  # use old metering svc
-  enableObjectStoreMetering: false
+  # Enable object store metering (objmt) svc instead of old metering svc
+  enableObjectStoreMetering: true
 
   # Enable object notification
   enableNotification: false


### PR DESCRIPTION
## Purpose
[OBSDEF-6119](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-6119)
Enable object store metering service by default

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

