### PR TITLE
[OBSDEF-6241] Remove schedule for pre-update check

### DIFF
--- a/ecs-cluster/templates/objectstore-app-configmap.yaml
+++ b/ecs-cluster/templates/objectstore-app-configmap.yaml
@@ -37,5 +37,4 @@ data:
         - name: pre-update
           container: {{.Values.global.registry}}/{{.Values.healthChecks.preUpdate.image.repository}}:{{default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
           serviceaccount: {{.Release.Name}}-healthchecks
-          schedule: "*/30 * * * *"
           timelimit: "5m"

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -22,7 +22,6 @@ data:
       spec:
         - name: pre-update
           container: {{.Values.global.registry}}/objectscale-manager-pre-update:{{.Values.tag}}
-          schedule: "*/30 * * * *"
           serviceaccount: {{ .Release.Name }}-healthchecks
           timelimit: "5m"
     eventRemedies: |-


### PR DESCRIPTION
The pre-update health checks should not run on a timer, they should be
run before a user is allowed to upgrade. The checks always require a
-target-version to be passed in to validate the upgrades is allowed.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-nnnn](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-nnnn)
_List the changes for this PR_

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

