### PR TITLE
NPS-8152 sshd in service-pod on openshift requires SYS_CHROOT capability

### DIFF
--- a/service-pod/templates/deployment.yaml
+++ b/service-pod/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
       - name: service-pod
         image: {{.Values.global.registry}}/{{.Values.image.repository | replace "base" .Values.global.product}}:{{default .Values.tag .Values.image.tag}}
         imagePullPolicy: {{default .Values.pullPolicy .Values.image.pullPolicy }}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_CHROOT
         ports:
         - containerPort: 22
           name: ssh


### PR DESCRIPTION
## Purpose
[NPS-8152] sshd in service-pod on openshift requires SYS_CHROOT capability

sshd is failing to chroot into /run/sshd, as a result it failing to accept ssh connection.
I did not customize the securityContext as it is not breaking functionality in non-openshift environments, for example with kubespray

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [x] helm test <release_name> passed

## Testing
ssh to service-pod in openshift environment

oc get svc -n nautilus-system service-pod-service-pod
NAME                      TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)        AGE
service-pod-service-pod   LoadBalancer   172.30.225.174   10.243.58.35   22:30243/TCP   106m

ssh root@10.243.58.35
root@10.243.58.35's password: 


* Welcome to the Dell EMC Service-Pod

The product for which you are connected is:
    Product:       streamingdata
    

Enjoy!!!



