### PR TITLE
NPS-8152 sshd in service-pod on openshift requires SYS_CHROOT capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HELM_VERSION := v3.0.3
 HELM_URL     := https://get.helm.sh
 HELM_TGZ      = helm-${HELM_VERSION}-linux-amd64.tar.gz
-YQ_VERSION   := 2.4.1
+YQ_VERSION   := 3.4.1
 YAMLLINT_VERSION := 1.20.0
 CHARTS := ecs-cluster objectscale-manager mongoose zookeeper-operator atlas-operator decks kahm srs-gateway dks-testapp fio-test sonobuoy dellemc-license service-pod
 DECKSCHARTS := decks kahm srs-gateway dks-testapp dellemc-license service-pod
@@ -37,8 +37,10 @@ dep:
 		helm plugin install https://github.com/lrills/helm-unittest ; \
  	fi
 	export PATH=$PATH:/tmp
+	wget -q http://asdrepo.isus.emc.com/artifactory/ecs-build/com/github/yq/${YQ_VERSION}/yq_linux_amd64
+	sudo mv yq_linux_amd64 /usr/bin/yq
+	sudo chmod u+x /usr/bin/yq
 	sudo pip install yamllint=="${YAMLLINT_VERSION}"
-	sudo pip install yq=="${YQ_VERSION}"
 
 decksver:
 	if [ -z $${DECKSVER} ] ; then \

--- a/decks/templates/decks.yaml
+++ b/decks/templates/decks.yaml
@@ -62,3 +62,7 @@ spec:
 {{- end }}
         - name: CONTROLLER_NAME
           value: decks
+        {{- if eq .Values.podSecurityContext.enabled true}}
+        - name: SERVICE_POD_SECURITY_CONTEXT
+          value: "true"
+        {{- end }}

--- a/decks/values.yaml
+++ b/decks/values.yaml
@@ -92,3 +92,6 @@ hooks:
   registry: "lachlanevenson"
   repository: "k8s-kubectl"
   tag: "v1.13.4"
+
+podSecurityContext:
+  enabled: false

--- a/service-pod/templates/deployment.yaml
+++ b/service-pod/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
 {{- else }}
         imagePullPolicy: {{ .Values.pullPolicy }}
 {{- end }}
+        {{- if .Values.podSecurityContext.enabled }}
+        securityContext:
+{{ toYaml .Values.podSecurityContext.securityContext | indent 10 }}
+        {{- end }}
         ports:
         - containerPort: 22 
           name: ssh 

--- a/service-pod/values.yaml
+++ b/service-pod/values.yaml
@@ -34,3 +34,11 @@ resources:
     storage: 10Gi
   limits:
     storage: 20Gi
+# service-pod securityContext, on openshift this context allows chroot capability
+# when installing on openshift run installer with podSecurityContext.enabled set to true
+podSecurityContext:
+  enabled: false
+  securityContext:
+    capabilities:
+      add:
+      - SYS_CHROOT


### PR DESCRIPTION
## Purpose
[NPS-8152] sshd in service-pod on openshift requires SYS_CHROOT capability
https://asdjira.isus.emc.com:8443/browse/NPS-8152

sshd is failing to chroot into /run/sshd, as a result it failing to accept ssh connection.
Since openshift 4.5.16 capability SYS_CHROOT was dropped from defaults, it needs to be explicitly mentioned in capabilities.
https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

On openshift:
with deck-install values
```
service-pod:
  podSecurityContext:
    enabled: true
```
service-pod-service-pod           LoadBalancer   172.30.251.63    10.243.58.35   22:30766/TCP                 30s

```
ssh root@10.243.58.35
root@10.243.58.35's password: 


* Welcome to the Dell EMC Service-Pod

The product for which you are connected is:
    Product:       streamingdata
    

Enjoy!!!

streamingdata-service-pod~# ls
streamingdata-service-pod~# 
```

kubespray cluster:
Installed with and without setting service-pod.podSecurityContext.enabled

```
service-pod-service-pod           LoadBalancer   10.233.23.53    10.243.38.214   22:31067/TCP                 2m16s

ubuntu@bm-ks-n195:~$ ssh root@10.243.38.214
root@10.243.38.214's password: 


* Welcome to the Dell EMC Service-Pod

The product for which you are connected is:
    Product:       streamingdata
    

Enjoy!!!

streamingdata-service-pod~# ls
streamingdata-service-pod~# 
```

### with new helm install changes for charts:
```
helm install d ./decks --set global.registry=asdrepo.isus.emc.com:9042 --set podSecurityContext.enabled=true
kubectl describe pod decks-...
   Restart Count:  0
    Environment:
      POD_NAME:                      decks-67cd9b8c7c-s79bw (v1:metadata.name)
      WATCH_NAMESPACE:               
      POD_NAMESPACE:                 default (v1:metadata.namespace)
      CONTROLLER_NAME:               decks
      SERVICE_POD_SECURITY_CONTEXT:  true
```

### then when configuring srsgateway:
```
helm install s ./srs-gateway --set product=STREAMINGDATA --set gateway.hostname=10.249.238.250 --set gateway.login=esrstest@arrow.com:Password1 --set registry=asdrepo.isus.emc.com:9042

kubectl get pod streamingdata-remote-access 
spec:
  containers:
  - env:
    - name: MY_POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
    - name: SRS_GW_CR_NAME
      value: streamingdata
    - name: DELL_EMC_PRODUCT
      value: STREAMINGDATA
    image: asdrepo.isus.emc.com:9042/remote-access:1.2.5
    imagePullPolicy: IfNotPresent
    name: remote-access
    ports:
    - containerPort: 22
      protocol: TCP
    resources: {}
    securityContext:
      capabilities:
        add:
        - SYS_CHROOT
```







