### PR TITLE
[OBSDEF-6327] Updating notes to use IAM credentials

### DIFF
--- a/ecs-cluster/templates/NOTES.txt
+++ b/ecs-cluster/templates/NOTES.txt
@@ -6,8 +6,10 @@ Your release is named {{ .Release.Name }}.
 
 To get started, simply read your access keys and endpoint(s):
 
-  $ read -r ACCESS_KEY SECRET_KEY \
-        <<<$(kubectl get secret {{ .Release.Name }}-initial-user -o jsonpath='{.data.accessKey}' | base64 -d; echo -n " "; kubectl get secret {{ .Release.Name }}-initial-user -o jsonpath='{.data.secretKey}' | base64 -d )
+  $ read -r ACCESS_KEY SECRET_KEY ACCOUNT_ID \
+        <<<$(kubectl -n {{ .Release.Namespace }} get secret {{ .Release.Name }}-initial-user -o jsonpath='{.data.IAM_ACCESS_KEY_ID}' | base64 -d; echo -n " "; \
+             kubectl -n {{ .Release.Namespace }} get secret {{ .Release.Name }}-initial-user -o jsonpath='{.data.IAM_SECRET_KEY}' | base64 -d; echo -n " "; \
+             kubectl -n {{ .Release.Namespace }} get secret {{ .Release.Name }}-initial-user -o jsonpath='{.data.IAM_ACCOUNT_ID}' | base64 -d )
 {{- if eq .Values.s3.service.type "LoadBalancer" }}
   $ read -r INTERNAL_ENDPOINT EXTERNAL_ENDPOINT \
         <<<$(kubectl get svc {{ .Release.Name }}-s3 \


### PR DESCRIPTION
## Purpose
[OBSDEF-6327](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-6327)
_List the changes for this PR_

## PR checklist
- [x] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
```
ben@ben:~/workspace/charts$ make test
helm lint ecs-cluster objectscale-manager mongoose zookeeper-operator atlas-operator decks kahm dks-testapp fio-test sonobuoy dellemc-license service-pod helm-controller objectscale-graphql objectscale-vsphere objectscale-portal objectscale-iam pravega-operator bookkeeper-operator supportassist decks-support-store statefuldaemonset-operator influxdb-operator federation logging-injector dcm --set product=objectscale --set global.product=objectscale
engine.go:159: [INFO] Missing required value: target.accessKey is required
engine.go:159: [INFO] Missing required value: .target.secretKey is required
engine.go:159: [INFO] Missing required value: target.addresses is required
engine.go:159: [INFO] Missing required value: target.port is required
engine.go:159: [INFO] Missing required value: SupportAssist Access Key must be specified
engine.go:159: [INFO] Missing required value: SupportAssist PIN must be specified
engine.go:159: [INFO] Missing required value: productVersion must be specified
engine.go:159: [INFO] Missing required value: siteID must be specified
==> Linting ecs-cluster

==> Linting objectscale-manager

==> Linting mongoose

==> Linting zookeeper-operator

==> Linting atlas-operator
[INFO] Chart.yaml: icon is recommended

==> Linting decks

==> Linting kahm

==> Linting dks-testapp
[INFO] Chart.yaml: icon is recommended

==> Linting fio-test

==> Linting sonobuoy

==> Linting dellemc-license
[INFO] Chart.yaml: icon is recommended

==> Linting service-pod

==> Linting helm-controller
[INFO] Chart.yaml: icon is recommended

==> Linting objectscale-graphql
[INFO] Chart.yaml: icon is recommended

==> Linting objectscale-vsphere
[INFO] Chart.yaml: icon is recommended

==> Linting objectscale-portal
[INFO] Chart.yaml: icon is recommended

==> Linting objectscale-iam

==> Linting pravega-operator

==> Linting bookkeeper-operator

==> Linting supportassist

==> Linting decks-support-store

==> Linting statefuldaemonset-operator
[INFO] Chart.yaml: icon is recommended

==> Linting influxdb-operator
[INFO] Chart.yaml: icon is recommended

==> Linting federation

==> Linting logging-injector
[INFO] Chart.yaml: icon is recommended

==> Linting dcm

26 chart(s) linted, 0 chart(s) failed
yamllint -c .yamllint.yml */Chart.yaml */values.yaml
atlas-operator/values.yaml
  24:4      warning  missing starting space in comment  (comments)

dcm/values.yaml
  37:3      warning  comment not indented like content  (comments-indentation)

ecs-cluster/values.yaml
  117:1     warning  comment not indented like content  (comments-indentation)
  121:1     warning  comment not indented like content  (comments-indentation)
  127:1     warning  comment not indented like content  (comments-indentation)
  158:1     warning  comment not indented like content  (comments-indentation)

objectscale-portal/values.yaml
  37:4      warning  missing starting space in comment  (comments)

yamllint -c .yamllint.yml -s .yamllint.yml .travis.yml
helm unittest ecs-cluster objectscale-manager mongoose zookeeper-operator atlas-operator decks kahm dks-testapp fio-test sonobuoy dellemc-license service-pod helm-controller objectscale-graphql objectscale-vsphere objectscale-portal objectscale-iam pravega-operator bookkeeper-operator supportassist decks-support-store statefuldaemonset-operator influxdb-operator federation logging-injector dcm

### Chart [ ecs-cluster ] ecs-cluster

 PASS  test svc logs	ecs-cluster/tests/svc_log4j2_test.yaml
 PASS  test ecs-cluster resource	ecs-cluster/tests/ecs_cluster_test.yaml
 PASS  test ecs-cluster resource	ecs-cluster/tests/initial_user_secret_test.yaml
 PASS  test ecs-cluster resource	ecs-cluster/tests/objectstore_rbac_test.yaml

### Chart [ objectscale-manager ] objectscale-manager

 PASS  test operator	objectscale-manager/tests/operator_test.yaml
 PASS  test rsyslog	objectscale-manager/tests/rsyslog_test.yaml
 PASS  test objectscale cluster resources	objectscale-manager/tests/objectscale-cluster-resources_test.yaml

### Chart [ mongoose ] mongoose


### Chart [ zookeeper-operator ] zookeeper-operator


### Chart [ atlas-operator ] atlas-operator

 PASS  test deployment	atlas-operator/tests/deployment_test.yaml
 PASS  test role binding	atlas-operator/tests/role_binding_test.yaml
 PASS  test role	atlas-operator/tests/role_test.yaml
 PASS  test serviceaccount	atlas-operator/tests/serviceaccount_test.yaml

### Chart [ decks ] decks

 PASS  test decks	decks/tests/decks_test.yaml

### Chart [ kahm ] kahm

 PASS  test ConfigMap	kahm/tests/ConfigMap_test.yaml
 PASS  test Headless-Service	kahm/tests/Headless-Service_test.yaml
 PASS  test kahm	kahm/tests/kahm_test.yaml

### Chart [ dks-testapp ] dks-testapp


### Chart [ fio-test ] fio-test

 PASS  test fio cronjob	fio-test/tests/fio_cronjonb_test.yaml

### Chart [ sonobuoy ] sonobuoy

 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_service_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_serviceaccount_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_clusterrole_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_clusterrolebinding_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_cronjob_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_namespace_test.yaml

### Chart [ dellemc-license ] dellemc-license


### Chart [ service-pod ] service-pod

 PASS  test service-pod deployment	service-pod/tests/deploy_test.yaml
 PASS  test service-pod service	service-pod/tests/service_test.yaml

### Chart [ helm-controller ] helm-controller

 PASS  test deployment resource	helm-controller/tests/deployment_test.yaml
 PASS  test deployment resource	helm-controller/tests/rest_credentials_secret_test.yaml
 PASS  test deployment resource	helm-controller/tests/service_test.yaml

### Chart [ objectscale-graphql ] objectscale-graphql

 PASS  test api role	objectscale-graphql/tests/object_store_monitor_role_test.yaml
 PASS  test api role	objectscale-graphql/tests/objectscale_admin_clusterrole_test.yaml
 PASS  test api role	objectscale-graphql/tests/objectscale_admin_role_test.yaml
 PASS  test objectscale api rbac	objectscale-graphql/tests/objectscale_api_rbac_test.yaml
 PASS  test graphql deployment	objectscale-graphql/tests/graphql_deploy_test.yaml
 PASS  test graphql service	objectscale-graphql/tests/graphql_service_test.yaml
 PASS  test api role	objectscale-graphql/tests/object_store_admin_role_test.yaml

### Chart [ objectscale-vsphere ] objectscale-vsphere

 PASS  test psp storage policy	objectscale-vsphere/tests/persistent-services-platform-sp-ha_test.yaml
 PASS  test psp operator	objectscale-vsphere/tests/persistent-services-platform-operator_test.yaml

### Chart [ objectscale-portal ] objectscale-portal


### Chart [ objectscale-iam ] objectscale-iam

 PASS  test iam deployment	objectscale-iam/tests/atlas_test.yaml
 PASS  test iam deployment	objectscale-iam/tests/deployment_test.yaml
 PASS  test iam service	objectscale-iam/tests/service_test.yaml

### Chart [ pravega-operator ] pravega-operator


### Chart [ bookkeeper-operator ] bookkeeper-operator


### Chart [ supportassist ] supportassist


### Chart [ decks-support-store ] decks-support-store

 PASS  test support store	decks-support-store/tests/support_store_test.yaml

### Chart [ statefuldaemonset-operator ] statefuldaemonset-operator

 PASS  test leader role	statefuldaemonset-operator/tests/leader_election_role_test.yaml
 PASS  test role binding	statefuldaemonset-operator/tests/role_binding_test.yaml
 PASS  test role	statefuldaemonset-operator/tests/role_test.yaml
 PASS  test role	statefuldaemonset-operator/tests/statefuldaemonset_editor_role_test.yaml
 PASS  test role	statefuldaemonset-operator/tests/statefuldaemonset_viewer_role_test.yaml
 PASS  test deployment	statefuldaemonset-operator/tests/deployment_test.yaml
 PASS  test leader role binding	statefuldaemonset-operator/tests/leader_election_role_binding_test.yaml

### Chart [ influxdb-operator ] influxdb-operator

 PASS  test role	influxdb-operator/tests/influxdb_editor_role_test.yaml
 PASS  test role	influxdb-operator/tests/influxdb_viewer_role_test.yaml
 PASS  test leader role binding	influxdb-operator/tests/leader_election_role_binding_test.yaml
 PASS  test leader role	influxdb-operator/tests/leader_election_role_test.yaml
 PASS  test role binding	influxdb-operator/tests/role_binding_test.yaml
 PASS  test role	influxdb-operator/tests/role_test.yaml
 PASS  test deployment	influxdb-operator/tests/deployment_test.yaml

### Chart [ federation ] federation


### Chart [ logging-injector ] logging-injector


### Chart [ dcm ] dcm


Charts:      26 passed, 26 total
Test Suites: 54 passed, 54 total
Tests:       258 passed, 258 total
Snapshot:    0 passed, 0 total
Time:        15.361017601s

```

