### PR TITLE
[OBSDEF-6350] Add default args for pre-upgrades

### DIFF
--- a/ecs-cluster/templates/objectstore-app-configmap.yaml
+++ b/ecs-cluster/templates/objectstore-app-configmap.yaml
@@ -38,3 +38,6 @@ data:
           container: {{.Values.global.registry}}/{{.Values.healthChecks.preUpdate.image.repository}}:{{default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
           serviceaccount: {{.Release.Name}}-healthchecks
           timelimit: "5m"
+          args:
+            - -target-version
+            - {{ .Values.tag .Values.healthChecks.preUpdate.image.tag }}

--- a/ecs-cluster/templates/objectstore-app-configmap.yaml
+++ b/ecs-cluster/templates/objectstore-app-configmap.yaml
@@ -40,4 +40,4 @@ data:
           timelimit: "5m"
           args:
             - -target-version
-            - {{ .Values.tag .Values.healthChecks.preUpdate.image.tag }}
+            - {{ default .Values.tag .Values.healthChecks.preUpdate.image.tag }}

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -24,6 +24,9 @@ data:
           container: {{.Values.global.registry}}/objectscale-manager-pre-update:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-healthchecks
           timelimit: "5m"
+          args:
+            - -target-version
+            - {{ .Values.tag .Values.healthChecks.preUpdate.image.tag}}
     eventRemedies: |-
       symptoms:
         - symptomid: DEOS-MGR-1001

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -26,7 +26,7 @@ data:
           timelimit: "5m"
           args:
             - -target-version
-            - {{ .Values.tag .Values.healthChecks.preUpdate.image.tag}}
+            - {{ default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
     eventRemedies: |-
       symptoms:
         - symptomid: DEOS-MGR-1001

--- a/objectscale-manager/values.yaml
+++ b/objectscale-manager/values.yaml
@@ -218,3 +218,10 @@ loggerConfig:
     durationEncoder: "string"
     # "full" or "short" caller info
     callerEncoder: "short"
+
+# KAHM health check configuration
+healthChecks:
+  preUpdate:
+    image:
+      repository: objectscale-manager-pre-update
+      # tag: stable


### PR DESCRIPTION
The pre-upgrade checks need a `-target-version` argument to know which
version a user is attempting to upgrade to. In the health check screen,
there is no option to choose a version, only a health check to run.
Default to using the current version so that the check can still run
successfully when called without arguments.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-6350](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-6350)


## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

