### PR TITLE
[OBSDEF-6337] Rebuild fix

### DIFF
--- a/objectscale-graphql/Chart.yaml
+++ b/objectscale-graphql/Chart.yaml
@@ -19,7 +19,7 @@ version: 0.69.1
 appVersion: 0.69.1
 dependencies:
   - name: helm-controller
-    version: 0.69.0
+    version: 0.69.1
     repository: file://../helm-controller
     condition: helmController.enabled
   - name: common-monitoring-lib

--- a/objectscale-portal/Chart.yaml
+++ b/objectscale-portal/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     url: https://dellemc.com
 dependencies:
   - name: objectscale-graphql
-    version: 0.69.0
+    version: 0.69.1
     repository: file://../objectscale-graphql
     condition: graphql.enabled
   - name: rsyslog-client

--- a/objectscale-vsphere/Chart.yaml
+++ b/objectscale-vsphere/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     url: https://dellemc.com
 dependencies:
   - name: objectscale-portal
-    version: 0.69.0
+    version: 0.69.1
     repository: file://../objectscale-portal


### PR DESCRIPTION
Fixes following broken re-build process:

```
git clone https://github.com/EMCECS/charts.git
...
make build
Error: can't get a valid version for dependency helm-controller
Error: can't get a valid version for dependency objectscale-portal
```
if clear chart package caches (as done in automation):
```
rm */charts/*
make build   -> same errors
make build
make package
Error: found in Chart.yaml, but missing in charts/ directory: objectscale-portal
Makefile:219: recipe for target 'create-vsphere-templates' failed
make: *** [create-vsphere-templates] Error 1
```