### PR TITLE
[OBSDEF-6572] - Log a kahm event when getting transaction error in callback

### DIFF
--- a/supportassist/templates/ese-callback-rbac.yaml
+++ b/supportassist/templates/ese-callback-rbac.yaml
@@ -38,6 +38,7 @@ rules:
   - extensions
   resources:
   - secrets
+  - events
   verbs:
   - "*"
 ---


### PR DESCRIPTION
## Purpose
[OBSDEF-6572](https://jira.cec.lab.emc.com/browse/OBSDEF-6572)
change rbac for callback to log events

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
Send a callback api request with a transaction error:
```
bash-4.4# curl --request POST --url 10.96.91.70:9447/objectscale/data --header 'content-type: application/json' --header 'x-dell-auth-key: tmpKey4U' --data '{"payloadType":"callback","payloadVersion":"1.0","data":{"operation":"event","transaction-id":"12345","sent-transaction-id":"54321","status":"failed","message":"1, '\''True'\''"}}'
```

Callback pod log:
```
time="2021-03-19T08:37:00Z" level=debug msg="authKey is tmpKey4U" func="util.GetAuthKeyUsingGoClient() " file="ese_helper.go:164"
time="2021-03-19T08:37:00Z" level=debug msg=Entering func="api.RestService.ESEData() " file="callback.go:32"
time="2021-03-19T08:37:00Z" level=info msg="Transaction result: Operation: event, TransactionID: 12345, SentTransactionID: 54321, Status: failed, Message: 1, 'True'" func="callbacksvcs.CallbackServices.ESEData() " file="callbacksvc.go:72"
W0319 08:37:00.078272       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
time="2021-03-19T08:37:00Z" level=debug msg=Exiting func="api.RestService.ESEData() " file="callback.go:54"
time="2021-03-19T08:37:00Z" level=info msg="POST /objectscale/data ESEData 11.204091ms" func="api.Logger.func1() " file="routers.go:121"
```

Event generated:
```
0s          Critical   ESE error           application/supportassist-objectscale                          Transaction failed Transaction result: Operation: event, TransactionID: 12345, SentTransactionID: 54321, Status: failed, Message: 1, 'True'
```

