### PR TITLE
[OBSDEF-6651] [OBSDEF-6775] [OBSDEF-193] - Charts update for build 70

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,6 @@ flexver: yqcheck graphqlver
 	done ;
 
 build: yqcheck
-	@echo "Ensure no helm repo accessible"
-	helm repo list | grep .; \
-        if [ $${?} -eq 0 ]; then exit 1; fi
 	REINDEX=0; \
 	for CHART in ${CHARTS}; do \
 		CURRENT_VER=`yq e .version $$CHART/Chart.yaml` ; \
@@ -209,7 +206,6 @@ create-manager-app: create-temp-package
 	--set objectscale-gateway.enabled=false ${HELM_MANAGER_ARGS} ${HELM_MONITORING_ARGS} \
 	--set objectscale-iam.enabled=true ${HELM_MANAGER_ARGS} ${HELM_MONITORING_ARGS} \
 	--set federation.enabled=true ${HELM_MANAGER_ARGS} ${HELM_MONITORING_ARGS} \
-	--set dcm.enabled=false ${HELM_MANAGER_ARGS} ${HELM_MONITORING_ARGS} \
 	-f values.yaml > ../${TEMP_PACKAGE}/yaml/objectscale-manager-app.yaml;
 	sed ${SED_INPLACE} 's/createApplicationResource\\":true/createApplicationResource\\":false/g' ${TEMP_PACKAGE}/yaml/objectscale-manager-app.yaml && \
 	sed ${SED_INPLACE} 's/\\"monitoring\\":{\\"enabled\\":false}/\\"monitoring\\":{\\"enabled\\":true}/g' ${TEMP_PACKAGE}/yaml/objectscale-manager-app.yaml && \

--- a/objectscale-manager/Chart.yaml
+++ b/objectscale-manager/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 0.69.1
+appVersion: 0.69.7
 description: |
   Dell EMC ObjectScale is highly scalable, and high performance S3 compatible object storage platform.
 name: objectscale-manager

--- a/objectscale-manager/values.yaml
+++ b/objectscale-manager/values.yaml
@@ -186,9 +186,9 @@ fluentbitAgent:
 
 # hook for VMWare platform
 hooks:
-  registry: "lachlanevenson"
+  registry: "emccorp"
   repository: "k8s-kubectl"
-  tag: "v1.13.4"
+  tag: "v1.16.10"
 
 loggerConfig:
   enabled: true


### PR DESCRIPTION
## Purpose
[OBSDEF-nnnn](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-nnnn)
- 6651 - enable dcm
- 6675 - use v1.16.10 for k8s-kubectl
- 193 - finally remove the helm repo check for make build

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
### deployed new plugin with these changes.  all services fired up along with gui 
```
─ $ ▶  kubectl get pod
NAME                                                              READY   STATUS      RESTARTS   AGE
atlas-operator-5bc9d7c5bb-7v75s                                   1/1     Running     0          29m
decks-5c6cb98697-4rmcr                                            1/1     Running     0          25m
decks-support-store-0                                             1/1     Running     0          25m
dellemc-eddie-697-domain-c44-wcp-sp-patch-gzbxm                   0/1     Completed   0          29m
fedsvc-857d9f6958-dhrms                                           1/1     Running     0          29m
fedsvc-857d9f6958-m888q                                           1/1     Running     0          29m
fedsvc-857d9f6958-v5bt8                                           1/1     Running     0          29m
kahm-96996c594-5pvrd                                              1/1     Running     0          25m
logging-injector-d7d965945-lb4xp                                  1/1     Running     0          30m
masterproxy-objectscale-dellemc-eddie-697-domain-c44-fh4zv        1/1     Running     0          28m
masterproxy-objectscale-dellemc-eddie-697-domain-c44-jkvv8        1/1     Running     0          29m
masterproxy-objectscale-dellemc-eddie-697-domain-c44-xkk5d        1/1     Running     0          29m
objectscale-graphql-776dc4f99-mbwc4                               2/2     Running     0          30m
objectscale-iam-684b6765b4-cwkvn                                  2/2     Running     0          29m
objectscale-iam-684b6765b4-k6589                                  2/2     Running     0          29m
objectscale-iam-684b6765b4-m5qqb                                  2/2     Running     0          29m
objectscale-iam-atlas-0                                           1/1     Running     0          28m
objectscale-iam-atlas-1                                           1/1     Running     0          28m
objectscale-iam-atlas-2                                           1/1     Running     0          28m
objectscale-install-controller-744bfcfb7d-f6qwr                   1/1     Running     0          30m
objectscale-manager-bookkeeper-operator-654f8c9f6-vxdxh           1/1     Running     0          29m
objectscale-manager-dcm-6847bc5d6d-h5mzj                          1/1     Running     0          29m
objectscale-manager-dcm-atlas-0                                   1/1     Running     0          28m
objectscale-manager-fluxd-76b8cd5db7-bpnxw                        3/3     Running     0          29m
objectscale-manager-grafana-76949b6dd4-fxs27                      5/5     Running     0          29m
objectscale-manager-influxdb-0                                    5/5     Running     0          28m
objectscale-manager-influxdb-1                                    5/5     Running     0          28m
objectscale-manager-influxdb-2                                    5/5     Running     0          28m
objectscale-manager-influxdb-operator-75689c974c-vxdkn            1/1     Running     0          29m
objectscale-manager-pravega-operator-6fbd5595c6-mtxkd             1/1     Running     0          29m
objectscale-manager-prometheus-alerts-7f85797687-bkxn9            3/3     Running     0          29m
objectscale-manager-rsyslog-0                                     3/3     Running     0          28m
objectscale-manager-rsyslog-1                                     3/3     Running     0          28m
objectscale-manager-rsyslog-2                                     3/3     Running     0          28m
objectscale-manager-rsyslog-3                                     3/3     Running     0          27m
objectscale-manager-rsyslog-4                                     3/3     Running     0          27m
objectscale-manager-service-pod-9db685847-nqlxx                   1/1     Running     0          29m
objectscale-manager-statefuldaemonset-operator-7b658bc547-nq4ff   1/1     Running     0          29m
objectscale-manager-telegraf-fc597fc4-x55tz                       3/3     Running     0          29m
objectscale-manager-throttler-565c66dccd-9b84z                    2/2     Running     0          29m
objectscale-operator-7446c765d7-5967j                             1/1     Running     0          29m
objectscale-portal-675f7bbf98-qthjk                               1/1     Running     0          30m
zookeeper-operator-58fff5875-5pmtp                                1/1     Running     0          29m
```

