### PR TITLE
[OBSDEF-6774] - Use std global.registrySecret to set imagePullSecrets

### DIFF
--- a/dcm/templates/deployment.yaml
+++ b/dcm/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
         {{- include "dcm.selectorLabels" . | nindent 8 }}
 {{ include "common-monitoring-lib.logging-inject-labels" . | indent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- if .Values.global.registrySecret }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        - name: {{ .Values.global.registrySecret }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/federation/templates/federation_deployment.yaml
+++ b/federation/templates/federation_deployment.yaml
@@ -16,10 +16,10 @@ spec:
         {{- include "fedsvc.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: "federation"
-    {{- with .Values.imagePullSecrets }}
+      {{- if .Values.global.registrySecret }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        - name: {{ .Values.global.registrySecret }}
+      {{- end }}
       containers:
       - name: fedsvc
         env:

--- a/objectscale-iam/templates/deployment.yaml
+++ b/objectscale-iam/templates/deployment.yaml
@@ -15,17 +15,10 @@ spec:
       labels:
         {{- include "iam.selectorLabels" . | nindent 8 }}
     spec:
-    {{- if .Values.global.registrySecret }}
+      {{- if .Values.global.registrySecret }}
       imagePullSecrets:
         - name: {{ .Values.global.registrySecret }}
-      {{- with .Values.imagePullSecrets }}
-      {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- else }}
-      {{- with .Values.imagePullSecrets }}
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- end }}
       containers:
       - name: iam
         env:


### PR DESCRIPTION
## Purpose
[OBSDEF-6774](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-6774)
- Updated iam, fed & dcm to standardize on global.registrySecret

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
- Built new charts and install-controller 
- Deployed on Andre all pods started:
![image](https://user-images.githubusercontent.com/7298642/112159654-c7152c00-8bbf-11eb-83bf-100c849af546.png)


