### PR TITLE
[OBSDEF-6936] set objectstore metering to default on

### DIFF
--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -74,7 +74,7 @@ features:
   enableCRR: false
 
   # use old metering svc
-  enableObjectStoreMetering: false
+  enableObjectStoreMetering: true
 
   # Enable object notification
   enableNotification: true


### PR DESCRIPTION
## Purpose
https://jira.cec.lab.emc.com/browse/OBSDEF-6936
set the objectstore metering svc to default enabled.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
helm install objectstore ecs-cluster --set global.registry=asdrepo.isus.emc.com:8099 \
> --set performanceProfile=small \
> --set tag=$objTag \
> --set fabricProxy.image.tag=shippable \
> --set managementGateway.image.tag=shippable \
> --set zookeeper.image.tag=shippable \
> --set zookeeper.persistence.storageClassName=$otherStorage \
> --set managementGateway.service.type=LoadBalancer \
> --set syslogAgent.image.tag=$rsyslogTag \
> --set storageServer.replicas=$ssReplicas \
> --set s3.service.type=LoadBalancer \
> --set diagnostic.service.type=LoadBalancer \
> --set provision.enabled=True \
> --set storageServer.persistence.protected=False \
> --set storageServer.persistence.storageClassName=$ssStorage \
> --set global.monitoring.enabled=false \
> --set provision.image.tag=$provisionTag \
> --set features.enableAdvancedStatistics=false  \
> --set influxdb.persistence.storageClassName=$otherStorage \
> --set atlas.persistence.storageClassName=$otherStorage \
> --set storageServer.persistence.volumesCount=2 \
> --set features.enableCRR=false \
> --set features.enableNotification=true \
> --set features.objectType=objectSVC \
> --set features.enablePravega=true \
> --set objectsvc.image.tag=$objectsvcTag \
> --set pravega.debugLogging=false \
> --set bookkeeper.storage.ledger.volumeSize=200Gi \
> --set bookkeeper.storage.journal.volumeSize=100Gi \
> --set bookkeeper.storage.index.volumeSize=50Gi \
> --set bookkeeper.storage.journal.storageClassName=baremetal-csi-sc-ssdlvg \
> --set bookkeeper.storage.ledger.storageClassName=baremetal-csi-sc-ssdlvg \
> --set bookkeeper.storage.index.storageClassName=baremetal-csi-sc-ssdlvg \
> --set global.monitoring.enabled=true \
> --set global.monitoring_registry=asdrepo.isus.emc.com:9042 \
> --set global.monitoring_tag=3.7.0.0-1146.a692701d \
> --set ecs-monitoring.grafana.service.type=LoadBalancer \
> --set ecs-monitoring.influxdb.persistence.storageClassName=baremetal-csi-sc-syslvg \
> --set pravega.image.tag=0.10.0-2831.d5f944ebf-issue-5853-SLTS-deep-copy \
> --set global.objectscale_release_name=objectscale-manager  \
> --set global.objectscale_namespace=default \
> --set ecs-monitoring.grafana.config.reverse_proxy.enabled=false \
> --set bookkeeper.options.log.level=info \
> --set pravega.debugLogging=false \
> --set objectStoreMetering.image.tag=3.7.0.0-132298.575363773b6 \
> --set ons.image.tag=3.7.0.0-132298.575363773b6 \
> --set s3.image.tag=3.7.0.0-132560.a2949e1fd03
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/.kube/config
NAME: objectstore
LAST DEPLOYED: Fri Apr  2 05:11:11 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing ecs-cluster. This release provides a Dell EMC
Elastic Cloud Storage (ECS) Clusters for a highly scalable, private,
S3-compatible object storage.
Your release is named objectstore.
To get started, simply read your access keys and endpoint(s):
  $ read -r ACCESS_KEY SECRET_KEY ACCOUNT_ID \
        <<<$(kubectl -n default get secret objectstore-initial-user -o jsonpath='{.data.IAM_ACCESS_KEY_ID}' | base64 -d; echo -n " "; \
             kubectl -n default get secret objectstore-initial-user -o jsonpath='{.data.IAM_SECRET_KEY}' | base64 -d; echo -n " "; \
             kubectl -n default get secret objectstore-initial-user -o jsonpath='{.data.IAM_ACCOUNT_ID}' | base64 -d )
  $ read -r INTERNAL_ENDPOINT EXTERNAL_ENDPOINT \
        <<<$(kubectl get svc objectstore-s3 \
        -o jsonpath='{.spec.clusterIP} {.status.loadBalancer.ingress[0].ip}')
NOTE: It may take a couple minutes for the Kubernetes cluster to assign a
      Load Balancer address. If it isn't set after a prolonged period, ensure
      that the Kubernetes cluster supports a "LoadBalancer" service type, or
      contact your Kubernetes provider support.

