### PR TITLE
[OBSDEF-6780] Sort CHARTS list by dependency order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ flexver: yqcheck graphqlver
 
 build: yqcheck
 	REINDEX=0; \
-	SORTED_CHARTS=`python tools/build_helper/sort_charts_by_deps.py ${CHARTS}`; \
+	SORTED_CHARTS=`python tools/build_helper/sort_charts_by_deps.py -c ${CHARTS}`; \
 	for CHART in ${SORTED_CHARTS}; do \
 		CURRENT_VER=`yq e .version $$CHART/Chart.yaml` ; \
 		yq e ".entries.$${CHART}[].version" docs/index.yaml | grep -q "\- $${CURRENT_VER}$$" ; \

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ flexver: yqcheck graphqlver
 build: yqcheck
 	REINDEX=0; \
 	SORTED_CHARTS=`python tools/build_helper/sort_charts_by_deps.py -c ${CHARTS}`; \
-	for CHART in ${SORTED_CHARTS}; do \
+	for CHART in $${SORTED_CHARTS}; do \
 		CURRENT_VER=`yq e .version $$CHART/Chart.yaml` ; \
 		yq e ".entries.$${CHART}[].version" docs/index.yaml | grep -q "\- $${CURRENT_VER}$$" ; \
 		if [ "$${?}" -eq "1" ] || [ "$${REBUILDHELMPKG}" ] ; then \

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ flexver: yqcheck graphqlver
 
 build: yqcheck
 	REINDEX=0; \
-	SORTED_CHARTS=`python tools/build_helper/sort_charts_by_deps.py ${CHARTS}`
+	SORTED_CHARTS=`python tools/build_helper/sort_charts_by_deps.py ${CHARTS}`; \
 	for CHART in ${SORTED_CHARTS}; do \
 		CURRENT_VER=`yq e .version $$CHART/Chart.yaml` ; \
 		yq e ".entries.$${CHART}[].version" docs/index.yaml | grep -q "\- $${CURRENT_VER}$$" ; \

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,8 @@ flexver: yqcheck graphqlver
 
 build: yqcheck
 	REINDEX=0; \
-	for CHART in ${CHARTS}; do \
+	SORTED_CHARTS=`python tools/build_helper/sort_charts_by_deps.py ${CHARTS}`
+	for CHART in ${SORTED_CHARTS}; do \
 		CURRENT_VER=`yq e .version $$CHART/Chart.yaml` ; \
 		yq e ".entries.$${CHART}[].version" docs/index.yaml | grep -q "\- $${CURRENT_VER}$$" ; \
 		if [ "$${?}" -eq "1" ] || [ "$${REBUILDHELMPKG}" ] ; then \

--- a/tools/build_helper/sort_charts_by_deps.py
+++ b/tools/build_helper/sort_charts_by_deps.py
@@ -4,9 +4,6 @@
 # Use to rebuild charts with dependencies only after rebuilding of their dependencies
 
 import os
-import sys
-import json
-import time
 import yaml
 import argparse
 

--- a/tools/build_helper/sort_charts_by_deps.py
+++ b/tools/build_helper/sort_charts_by_deps.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+# Script to sort charts for rebuild in order of resolved dependencies
+# Use to rebuild charts with dependencies only after rebuilding of their dependencies
+
+import os
+import sys
+import json
+import time
+import yaml
+import argparse
+
+acharts = dict()
+
+def get_yaml(ifl):
+    try:
+        with open(ifl, "r+") as tx:
+            return yaml.safe_load(tx)
+    except:
+        raise Exception("Failed to load yaml from {}".format(ifl))
+
+def walk_in_deps(ch, dep_rec):
+    dns = []
+    for dp in dep_rec:
+        repo = dp['repository']
+        if repo.startswith('file://../'):       # store deps in local repo only
+            dns.append(repo.split('/')[-1])
+    acharts[ch] = dns
+
+def fill_chart_deps(ch, vfile, rfile):
+    rec = get_yaml(vfile)
+    acharts[ch] = []
+    if 'dependencies' in rec:
+        walk_in_deps(ch, rec['dependencies'])
+    else:
+        if os.path.exists(rfile):
+            rec = get_yaml(rfile)
+            if 'dependencies' in rec:
+                walk_in_deps(ch, rec['dependencies'])
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--charts", help="space-separated list of charts", required=True, nargs='+')
+args = parser.parse_args()
+
+for ch in args.charts:
+    vfile = os.path.join(ch, 'Chart.yaml')
+    rfile = os.path.join(ch, 'requirements.yaml')
+    if os.path.exists(vfile):
+        fill_chart_deps(ch, vfile, rfile)
+    else:
+        raise Exception("Expect file {} is not found".format(vfile))
+
+for ch in acharts.keys():
+    extra_check = list(set(acharts[ch]) - set(acharts.keys()))
+    if extra_check:
+        raise Exception("Extra, non-referred local chart deps {} in '{}'".format(extra_check, ch))
+
+rs = []
+while bool(acharts):
+    for ch in sorted(acharts.keys()):
+        if len(acharts[ch]) == 0:                           # collect and exclude charts without deps
+            rs.append(ch)
+            del acharts[ch]
+    for ch in acharts.keys():
+        acharts[ch] = list(set(acharts[ch]) - set(rs))      # remove processed from remained charts
+
+print(" ".join(rs))


### PR DESCRIPTION
Wrong order of initial CHARTS list leads to build issues, like using cached chart package of dependency in chart that requires newly rebuilt package.
Fix order of CHARTS in build time so that dependent charts are always built in the end.
Tested by running `make build`, verifying that sort script works as expected.