### PR TITLE
[OBSDEF-7081] Add fed svc name env variable in the operator

### DIFF
--- a/objectscale-manager/templates/operator.yaml
+++ b/objectscale-manager/templates/operator.yaml
@@ -97,6 +97,8 @@ spec:
               fieldPath: metadata.namespace
         - name: PLATFORM
           value: {{ .Values.global.platform | default "Default" }}
+        - name: FEDERATION_SERVICE_NAME
+          value: "fedsvc"
 {{- if .Values.dcm.enabled }}
         - name: DCM_SERVICE_HOSTNAME
           value: "{{ .Release.Name }}-dcm"


### PR DESCRIPTION
## Purpose
[OBSDEF-7081](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-7081)
Added environment variable with federation servie name to resolve DNS name for REST requests in the operator.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
```
kubectl exec objectscale-operator-5b8855dc58-9pjpp -- printenv | grep FEDERATION
FEDERATION_SERVICE_NAME=fedsvc
```