### PR TITLE
Add labels to configmaps

### DIFF
--- a/decks/templates/decks-app-configmap.yaml
+++ b/decks/templates/decks-app-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
         app.kubernetes.io/version: {{.Values.tag}}
         app.kubernetes.io/instance: {{.Release.Name}}
         app.kubernetes.io/managed-by: nautilus
+        app.kubernetes.io/type: app-config
         helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
         release: {{.Release.Name}}
     annotations:

--- a/dellemc-license/templates/dellemc-license-app-configmap.yaml
+++ b/dellemc-license/templates/dellemc-license-app-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
         app.kubernetes.io/version: {{.Values.tag}}
         app.kubernetes.io/instance: {{.Release.Name}}
         app.kubernetes.io/managed-by: {{.Release.Service}}
+        app.kubernetes.io/type: app-config
         helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
         release: {{.Release.Name}}
         product: {{.Values.product}}

--- a/ecs-cluster/templates/objectstore-app-configmap.yaml
+++ b/ecs-cluster/templates/objectstore-app-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
       app.kubernetes.io/version: {{.Values.tag}}
       app.kubernetes.io/instance: {{.Release.Name}}
       app.kubernetes.io/managed-by: {{.Release.Service}}
+      app.kubernetes.io/type: app-config
       helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
       product: objectscale
       release: {{.Release.Name}}

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       app.kubernetes.io/version: {{ .Chart.AppVersion }}
       app.kubernetes.io/part-of: {{ .Release.Name }}
+      app.kubernetes.io/type: app-config
       helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       release: {{ .Release.Name}}
       operator: objectscale-operator

--- a/supportassist/templates/supportassist-app-configmap.yaml
+++ b/supportassist/templates/supportassist-app-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
         app.kubernetes.io/version: {{.Values.tag}}
         app.kubernetes.io/instance: {{.Release.Name}}
         app.kubernetes.io/managed-by: {{.Release.Service}}
+        app.kubernetes.io/type: app-config
         helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
         release: {{.Release.Name}}
         product: {{.Values.product}}


### PR DESCRIPTION
Add a type label to the <release>-app-config so we can easily filter them in GraphQL or KAHM when looking for updates to health checks that have run.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-7183](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-7183)

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing


