### PR TITLE
[OBSDEF-3054] export georeceiver external endpoint

### DIFF
--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -569,7 +569,7 @@ geoReceiver:
     ports:
       - name: geo
         port: 9094
-      - name: external
+      - name: http-external # is should be changed to https when TLS integrated
         port: 12002
         targetPort: 12002
 

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -569,7 +569,7 @@ geoReceiver:
     ports:
       - name: geo
         port: 9094
-      - name: http-external # is should be changed to https when TLS integrated
+      - name: http-external # should be changed to https when TLS integrated
         port: 12002
         targetPort: 12002
 


### PR DESCRIPTION
## Purpose
[OBSDEF-3054](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-3054)
Add "http" prefix to georeciver CRR endpoint to be picked by operator to register to federation service

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed


