### PR TITLE
[OBSDEF-1856] Update the charts for cloud iq inventory and health report

### DIFF
--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -27,12 +27,12 @@ data:
           args:
             - -target-version
             - {{ default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
-        - name: cloudiq-inventory-report
-          container: {{.Values.global.registry}}/objectstore-inventory:{{.Values.tag}}
+        - name: cloudiq-inventory
+          container: {{.Values.global.registry}}/objectscale-inventory:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-healthchecks
           schedule: "0 */6 * * *"
           timelimit: "5m"
-        - name: cloudiq-health-report
+        - name: cloudiq-health
           container: {{.Values.global.registry}}/objectstore-health:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-healthchecks
           schedule: "0 */6 * * *"

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -27,6 +27,16 @@ data:
           args:
             - -target-version
             - {{ default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
+        - name: cloudiq-inventory-report
+          container: {{.Values.global.registry}}/objectstore-inventory:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-healthchecks
+          schedule: "0 */6 * * *"
+          timelimit: "5m"
+        - name: cloudiq-health-report
+          container: {{.Values.global.registry}}/objectstore-health:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-healthchecks
+          schedule: "0 */6 * * *"
+          timelimit: "5m"
     eventRemedies: |-
       symptoms:
         - symptomid: DEOS-MGR-1001


### PR DESCRIPTION
Signed-off-by: Youmin_Han <Youmin_Han@dell.com>

## Purpose
[OBSDEF-1856](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-1856)
Add the sub charts under objectscale manager to generate the report for inventory and health data. 

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

