### PR TITLE
charts changes required for Telemetry collections and uploads

### DIFF
--- a/objectscale-manager/templates/cloudiq-rbac.yaml
+++ b/objectscale-manager/templates/cloudiq-rbac.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-inventory-report
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.registrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.registrySecret }}
+  {{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-inventory-report
+  labels:
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-inventory-report
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-inventory-report
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-inventory-report
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-capacity-report
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.registrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.registrySecret }}
+  {{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-capacity-report
+  labels:
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-capacity-report
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-capacity-report
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-capacity-report
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-performance-report
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.registrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.registrySecret }}
+  {{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-performance-report
+  labels:
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-performance-report
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-performance-report
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-performance-report
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-health-report
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.registrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.registrySecret }}
+  {{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-health-report
+  labels:
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-health-report
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-health-report
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-health-report
+  apiGroup: rbac.authorization.k8s.io

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -18,7 +18,7 @@ metadata:
         com.dellemc.kahm.subscribed: "true"
 data:
     eventRules: |-
-    health: |-
+    healthAndReports: |-
       spec:
         - name: pre-update
           container: {{.Values.global.registry}}/objectscale-manager-pre-update:{{.Values.tag}}
@@ -27,6 +27,26 @@ data:
           args:
             - -target-version
             - {{ default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
+        - name: inventory-report 
+          container: {{.Values.global.registry}}/objectscale-inventory-report:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-inventory-report
+          timelimit: "5m"
+          schedule: {{ default "0 * * * *" .Values.healthChecksAndReports.inventoryReport.schedule }}
+        - name: capacity-report 
+          container: {{.Values.global.registry}}/objectscale-capacity-report:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-capacity-report
+          timelimit: "5m"
+          schedule: {{ default "0 * * * *" .Values.healthChecksAndReports.capacityReport.schedule }}
+        - name: performance-report 
+          container: {{.Values.global.registry}}/objectscale-performance-report:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-performance-report
+          timelimit: "5m"
+          schedule: {{ default "*/5 * * * *" .Values.healthChecksAndReports.performanceReport.schedule }}
+        - name: health-report 
+          container: {{.Values.global.registry}}/objectscale-health-report:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-health-report
+          timelimit: "5m"
+          schedule: {{ default "*/5 * * * *" .Values.healthChecksAndReports.healthReport.schedule }}
     eventRemedies: |-
       symptoms:
         - symptomid: DEOS-MGR-1001

--- a/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app-configmap.yaml
@@ -18,7 +18,7 @@ metadata:
         com.dellemc.kahm.subscribed: "true"
 data:
     eventRules: |-
-    healthAndReports: |-
+    health: |-
       spec:
         - name: pre-update
           container: {{.Values.global.registry}}/objectscale-manager-pre-update:{{.Values.tag}}
@@ -27,26 +27,30 @@ data:
           args:
             - -target-version
             - {{ default .Values.tag .Values.healthChecks.preUpdate.image.tag}}
-        - name: inventory-report 
+        - name: inventory-report
           container: {{.Values.global.registry}}/objectscale-inventory-report:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-inventory-report
           timelimit: "5m"
-          schedule: {{ default "0 * * * *" .Values.healthChecksAndReports.inventoryReport.schedule }}
+          schedule: {{ default "0 * * * *" .Values.healthChecks.inventoryReport.schedule }}
+          disabled: {{ default false .values.healthChecks.inventoryReport.disabled }}
         - name: capacity-report 
           container: {{.Values.global.registry}}/objectscale-capacity-report:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-capacity-report
           timelimit: "5m"
-          schedule: {{ default "0 * * * *" .Values.healthChecksAndReports.capacityReport.schedule }}
+          schedule: {{ default "0 * * * *" .Values.healthChecks.capacityReport.schedule }}
+          disabled: {{ default false .values.healthChecks.capacityReport.disabled }}
         - name: performance-report 
           container: {{.Values.global.registry}}/objectscale-performance-report:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-performance-report
           timelimit: "5m"
-          schedule: {{ default "*/5 * * * *" .Values.healthChecksAndReports.performanceReport.schedule }}
+          schedule: {{ default "*/5 * * * *" .Values.healthChecks.performanceReport.schedule }}
+          disabled: {{ default false .values.healthChecks.performanceReport.disabled }}
         - name: health-report 
           container: {{.Values.global.registry}}/objectscale-health-report:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-health-report
           timelimit: "5m"
-          schedule: {{ default "*/5 * * * *" .Values.healthChecksAndReports.healthReport.schedule }}
+          schedule: {{ default "*/5 * * * *" .Values.healthChecks.healthReport.schedule }}
+          disabled: {{ default false .values.healthChecks.healthReport.disabled }}
     eventRemedies: |-
       symptoms:
         - symptomid: DEOS-MGR-1001

--- a/objectscale-manager/values.yaml
+++ b/objectscale-manager/values.yaml
@@ -232,8 +232,28 @@ loggerConfig:
     callerEncoder: "short"
 
 # KAHM health check configuration
-healthChecks:
+healthChecksAndReports:
   preUpdate:
     image:
       repository: objectscale-manager-pre-update
       # tag: stable
+  inventoryReport:
+    image:
+      repository: objectscale-inventory-report
+      tag: 0.71.2 
+    schedule: "0 * * * *"
+  capacityReport:
+    image:
+      repository: objectscale-capacity-report
+      tag: 0.71.2 
+    schedule: "0 * * * *"
+  performanceReport:
+    image:
+      repository: objectscale-performance-report
+      tag: 0.71.2 
+    schedule: "*/10 * * * *"
+  healthReport:
+    image:
+      repository: objectscale-health-report
+      tag: 0.71.2 
+    schedule: "*/10 * * * *"

--- a/objectscale-manager/values.yaml
+++ b/objectscale-manager/values.yaml
@@ -232,7 +232,7 @@ loggerConfig:
     callerEncoder: "short"
 
 # KAHM health check configuration
-healthChecksAndReports:
+healthChecks:
   preUpdate:
     image:
       repository: objectscale-manager-pre-update
@@ -242,18 +242,22 @@ healthChecksAndReports:
       repository: objectscale-inventory-report
       tag: 0.71.2 
     schedule: "0 * * * *"
+    disabled: true
   capacityReport:
     image:
       repository: objectscale-capacity-report
       tag: 0.71.2 
     schedule: "0 * * * *"
+    disabled: true
   performanceReport:
     image:
       repository: objectscale-performance-report
       tag: 0.71.2 
     schedule: "*/10 * * * *"
+    disabled: true
   healthReport:
     image:
       repository: objectscale-health-report
       tag: 0.71.2 
     schedule: "*/10 * * * *"
+    disabled: true

--- a/supportassist/templates/cloudiq-rbac.yaml
+++ b/supportassist/templates/cloudiq-rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-telemetry-upload
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.registrySecret }}
+imagePullSecrets:
+  - name: {{ .Values.global.registrySecret }}
+  {{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-telemetry-upload
+  labels:
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-telemetry-upload
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-telemetry-upload
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-telemetry-upload
+  apiGroup: rbac.authorization.k8s.io

--- a/supportassist/templates/supportassist-app-configmap.yaml
+++ b/supportassist/templates/supportassist-app-configmap.yaml
@@ -33,4 +33,25 @@ data:
             - Is SupportAssist still disabled?
             - Verify connectivity of configured gateways.
             - Verify a valid AccessKey and PIN were used.
-    healthChecks: |-
+    healthAndReports: |-
+      spec:
+        - name: inventory-report
+          container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-telemetry-upload
+          timelimit: "5m"
+          schedule: {{ default "0 * * * *" .Values.cloudIQ.inventoryReport.schedule }}
+        - name: capacity-report
+          container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-telemetry-upload
+          timelimit: "5m"
+          schedule: {{ default "0 * * * *" .Values.cloudIQ.capacityReport.schedule }}
+        - name: performance-report
+          container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-telemetry-upload
+          timelimit: "5m"
+          schedule: {{ default "0 * * * *" .Values.cloudIQ.performanceReport.schedule }}
+        - name: health-report
+          container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
+          serviceaccount: {{ .Release.Name }}-telemetry-upload
+          timelimit: "5m"
+          schedule: {{ default "0 * * * *" .Values.cloudIQ.healthReport.schedule }}

--- a/supportassist/templates/supportassist-app-configmap.yaml
+++ b/supportassist/templates/supportassist-app-configmap.yaml
@@ -33,25 +33,41 @@ data:
             - Is SupportAssist still disabled?
             - Verify connectivity of configured gateways.
             - Verify a valid AccessKey and PIN were used.
-    healthAndReports: |-
+    health: |-
       spec:
         - name: inventory-report
           container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-telemetry-upload
           timelimit: "5m"
           schedule: {{ default "0 * * * *" .Values.cloudIQ.inventoryReport.schedule }}
+          args:
+            - -folder
+            - {{ .Values.cloudIQ.inventoryReport.folder}}
+          disabled: {{ default false .values.healthChecks.inventoryReport.disabled }}
         - name: capacity-report
           container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-telemetry-upload
           timelimit: "5m"
           schedule: {{ default "0 * * * *" .Values.cloudIQ.capacityReport.schedule }}
+          args:
+            - -folder
+            - {{ .Values.cloudIQ.capacityReport.folder}}
+          disabled: {{ default false .values.healthChecks.capacityReport.disabled }}
         - name: performance-report
           container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-telemetry-upload
           timelimit: "5m"
           schedule: {{ default "0 * * * *" .Values.cloudIQ.performanceReport.schedule }}
+          args:
+            - -folder
+            - {{ .Values.cloudIQ.performanceReport.folder}}
+          disabled: {{ default false .values.healthChecks.performanceReport.disabled }}
         - name: health-report
           container: {{.Values.global.registry}}/telemetry-upload:{{.Values.tag}}
           serviceaccount: {{ .Release.Name }}-telemetry-upload
           timelimit: "5m"
           schedule: {{ default "0 * * * *" .Values.cloudIQ.healthReport.schedule }}
+          args:
+            - -folder
+            - {{ .Values.cloudIQ.healthReport.folder}}
+          disabled: {{ default false .values.healthChecks.healthReport.disabled }}

--- a/supportassist/values.yaml
+++ b/supportassist/values.yaml
@@ -125,3 +125,34 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# cloudIQ
+cloudIQ:
+  inventoryReport:
+    image:
+      repository: telemetry-upload
+      # tag: 0.71.2
+    schedule: "0 * * * *"
+    disabled: true
+    folder: inventory_report
+  capacityReport:
+    image:
+      repository: telemetry-upload
+      # tag: 0.71.2
+    schedule: "0 * * * *"
+    disabled: true
+    folder: capacity_report
+  performanceReport:
+    image:
+      repository: telemetry-upload
+      # tag: 0.71.2
+    schedule: "*/10 * * * *"
+    disabled: true
+    folder: performance_report
+  healthReport:
+    image:
+      repository: telemetry-upload
+      # tag: 0.71.2
+    schedule: "*/10 * * * *"
+    disabled: true
+    folder: health_report


### PR DESCRIPTION
## Purpose
[OBSDEF-1830](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-1830)
The health framework will be used generate telemetry reports at objectscale-manager level and the same will be used to upload the reports at support-assist application level.
The customer and charts will provide the option to modify the followings:
1. Enable or Disable reports
2. Schedule

By using the health check framework, we can run these reports on demand basis in additon to the periodic reports.


## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

