### PR TITLE
[OBSDEF-7817] - added namespace in the cluster role and cluster role bindings names

### DIFF
--- a/objectscale-manager/templates/telemetry-rbac.yaml
+++ b/objectscale-manager/templates/telemetry-rbac.yaml
@@ -12,7 +12,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-inventory
+  name: {{ .Release.Namespace }}-inventory
   labels:
     release: {{ .Release.Name }}
 rules:
@@ -47,7 +47,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-inventory
+  name: {{ .Release.Namespace }}-inventory
   labels:
     release: {{ .Release.Name }}
 subjects:
@@ -56,7 +56,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-inventory
+  name: {{ .Release.Namespace }}-inventory
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -75,7 +75,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-capacity
+  name: {{ .Release.Namespace }}-capacity
   labels:
     release: {{ .Release.Name }}
 rules:
@@ -86,7 +86,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-capacity
+  name: {{ .Release.Namespace }}-capacity
   labels:
     release: {{ .Release.Name }}
 subjects:
@@ -95,7 +95,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-capacity
+  name: {{ .Release.Namespace }}-capacity
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -114,7 +114,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-performance
+  name: {{ .Release.Namespace }}-performance
   labels:
     release: {{ .Release.Name }}
 rules:
@@ -125,7 +125,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-performance
+  name: {{ .Release.Namespace }}-performance
   labels:
     release: {{ .Release.Name }}
 subjects:
@@ -134,7 +134,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-performance
+  name: {{ .Release.Namespace }}-performance
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -151,7 +151,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-health
+  name: {{ .Release.Namespace }}-health
   labels:
     release: {{ .Release.Name }}
 rules:
@@ -176,7 +176,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-health
+  name: {{ .Release.Namespace }}-health
   labels:
     release: {{ .Release.Name }}
 subjects:
@@ -185,5 +185,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-health
+  name: {{ .Release.Namespace }}-health
   apiGroup: rbac.authorization.k8s.io

--- a/supportassist/templates/telemetry-rbac.yaml
+++ b/supportassist/templates/telemetry-rbac.yaml
@@ -12,7 +12,7 @@ imagePullSecrets:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-telemetry-upload
+  name: {{ .Release.Namespace }}-telemetry-upload
   labels:
     release: {{ .Release.Name }}
 rules:
@@ -23,7 +23,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-telemetry-upload
+  name: {{ .Release.Namespace }}-telemetry-upload
   labels:
     release: {{ .Release.Name }}
 subjects:
@@ -32,5 +32,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-telemetry-upload
+  name: {{ .Release.Namespace }}-telemetry-upload
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Purpose
[OBSDEF-7817](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-7817)
Need to add namespace as a part of the cluster role and cluster role bindings for inventory charts as we need to create mukltiple objectscales across the namespaces.

## PR checklist
- [x ] make test passed
- [x ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

