### PR TITLE
[OBSDEF-6862] Correction for monitoring image tags

### DIFF
--- a/influxdb-operator/values.yaml
+++ b/influxdb-operator/values.yaml
@@ -20,7 +20,8 @@ global:
 
 image:
   repository: influxdb-operator
-  tag: 3.7.0.0-1186.91aed4d8 # rfw-update-this influxdb-operator-docker-image
+  # no need to insert rfw marker here because version comes from global.monitoring_tag
+  # tag: stable
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/statefuldaemonset-operator/values.yaml
+++ b/statefuldaemonset-operator/values.yaml
@@ -20,7 +20,8 @@ global:
 
 image:
   repository: statefuldaemonset-operator
-  tag: 3.7.0.0-1186.91aed4d8 # rfw-update-this statefuldaemonset-operator-docker-image
+  # no need to insert rfw marker here because version comes from global.monitoring_tag
+  # tag: stable
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
It turned that inserted monitoring tags break monitoring build/CI, and since their versions are inserted via global tag, it is better to skip their insertions.