### PR TITLE
[ATL-1704] set resource requests and limits to avoid kahm pod crash

### DIFF
--- a/kahm/templates/kahm.yaml
+++ b/kahm/templates/kahm.yaml
@@ -46,6 +46,10 @@ spec:
         volumeMounts:
         - mountPath: /data/db
           name: db
+        resources:
+        {{- if .Values.resources }}
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
## Purpose
[ATL-1704](https://jira.cec.lab.emc.com/browse/ATL-1704)

set the resource requests/limits as per the values passed.

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

```
k get po -n nautilus-system kahm-7f6f4795d9-4z7kh -o yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2021-05-06T19:09:14Z"
  generateName: kahm-7f6f4795d9-
  labels:
    app: kahm
    name: kahm
    pod-template-hash: 7f6f4795d9
    release: kahm
  name: kahm-7f6f4795d9-4z7kh
  namespace: nautilus-system
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: ReplicaSet
    name: kahm-7f6f4795d9
    uid: 4d943d52-6452-4710-bb78-c7730d87f5e6
  resourceVersion: "3026614"
  selfLink: /api/v1/namespaces/nautilus-system/pods/kahm-7f6f4795d9-4z7kh
  uid: 44e7bc16-3c5d-4a87-bb52-a6f151042cfc
spec:
  containers:
  - command:
    - kahm
    env:
    - name: POD_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: MY_POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
    - name: WATCH_NAMESPACE
    - name: KAHM_DB_TYPE
      valueFrom:
        configMapKeyRef:
          key: dbType
          name: kahm-db-config
    - name: KAHM_DB_EVENT_TTL
      valueFrom:
        configMapKeyRef:
          key: eventTTL
          name: kahm-db-config
    image: devops-repo.isus.emc.com:8116/nautilus/kahm:1.2.7
    imagePullPolicy: IfNotPresent
    name: kahm
    ports:
    - containerPort: 60000
      name: metrics
      protocol: TCP
    - containerPort: 17999
      name: rest
      protocol: TCP
    resources:
      limits:
        cpu: 100m
        memory: 2Gi
      requests:
        cpu: 100m
        memory: 2Gi
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /data/db
      name: db
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kahm-token-2kdzk
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: node1
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: kahm
  serviceAccountName: kahm
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: db
    persistentVolumeClaim:
      claimName: db-kahm-0
  - name: kahm-token-2kdzk
    secret:
      defaultMode: 420
      secretName: kahm-token-2kdzk
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2021-05-06T19:09:14Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2021-05-06T19:09:17Z"
    status: "True"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2021-05-06T19:09:17Z"
    status: "True"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2021-05-06T19:09:14Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - containerID: docker://558e4d5aa638b9ca39240c53334336b08459050458eb587024cc55f334048246
    image: devops-repo.isus.emc.com:8116/nautilus/kahm:1.2.7
    imageID: docker-pullable://devops-repo.isus.emc.com:8116/nautilus/kahm@sha256:79013eb5e401579cbc619b3d42c443b2793f0c5d98bfee39813adf733d3a67dd
    lastState: {}
    name: kahm
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2021-05-06T19:09:17Z"
  hostIP: 10.243.38.201
  phase: Running
  podIP: 10.233.90.101
  podIPs:
  - ip: 10.233.90.101
  qosClass: Guaranteed
  startTime: "2021-05-06T19:09:14Z"
```