### PR TITLE
OBSDEF-7064 Add validation for ECS Cluster

### DIFF
--- a/objectscale-manager/crds/ecscluster.yaml
+++ b/objectscale-manager/crds/ecscluster.yaml
@@ -49,4 +49,4 @@ spec:
           properties:
             name:
               type: string
-              maxLength: 26
+              maxLength: 31

--- a/objectscale-manager/crds/ecscluster.yaml
+++ b/objectscale-manager/crds/ecscluster.yaml
@@ -49,4 +49,4 @@ spec:
           properties:
             name:
               type: string
-              maxLength: 27
+              maxLength: 26

--- a/objectscale-manager/crds/ecscluster.yaml
+++ b/objectscale-manager/crds/ecscluster.yaml
@@ -41,3 +41,12 @@ spec:
     type: string
     description: The HTTPS location for the management API
     JSONPath: .status.endpoints.managementAPI
+  validation:
+    openAPIV3Schema:
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              maxLength: 27


### PR DESCRIPTION
## Purpose
[OBSDEF-7064](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-7064)
1. Add name length validation using `openAPIV3Schema`

## PR checklist
- [ 1] make test passed
- [ ] make build passed
- [ 1] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
1. Positive case with 27 characters
```
CLUSTER_RELEASE=${ECS_RELEASE:-ecs-cluster-with-a-very-lon}

[root@charlie:~]$ kubectl get pod
NAME                                                              READY   STATUS    RESTARTS   AGE
atlas-operator-76c655fd79-mbd4j                                   1/1     Running   0          2d16h
ecs-cluster-with-a-very-lon-management-gateway-5b6756d9b7-cnqh6   1/1     Running   0          2d16h

```
```
[root@charlie:~]$ curl $(kubectl get svc |grep "9101" | awk '{print $3":9101/stats/dt/DTInitStat/"}' ) | xmllint -format -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   260  100   260    0     0   1333      0 --:--:-- --:--:-- --:--:--  1340
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<result>
  <entry>
    <total_dt_num>56</total_dt_num>
    <unready_dt_num>0</unready_dt_num>
    <unknown_dt_num>0</unknown_dt_num>
    <dump_failure_num>0</dump_failure_num>
    <RIS_failure_num>0</RIS_failure_num>
  </entry>
</result>

```

2. Negative case with many characters

```
CLUSTER_RELEASE=${ECS_RELEASE:-ecs-cluster-with-very-long-name-heiheihei}

Error: ECSCluster.ecs.dellemc.com "ecs-cluster-with-very-long-name-heiheihei" is invalid: metadata.name: Invalid value: "": metadata.name in body should be at most 27 chars long

```