### PR TITLE
Feature flag for managerObjectStoreV2 will be enabled by default

### DIFF
--- a/objectscale-portal/values.yaml
+++ b/objectscale-portal/values.yaml
@@ -94,7 +94,7 @@ features:
   # enable this if you want to deploy the BETA3 Buckets workflows
   bucketsv2: true
   # enable this if you want to deploy the BETA3 New/Edit Objectstore workflows
-  manageObjectStoreV2: false
+  manageObjectStoreV2: true
   replications: false
   objectscaleSystems: false
   # Possible Logging modes - ERROR, INFO, DEBUG, WARNING Only


### PR DESCRIPTION
## Purpose
[OBSDEF-7310](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-7310)
_List the changes for this PR_
managerObjectStoreV2  Feature flag enabled by default,  The new Object store creation workflow will be enabled by default.

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
We have tried to enable this flag and see that the new Object Store UI Launches.
At Runtime, we tried to enabled/disable this flag to see if the old vs new UI Launches properly.

