### PR TITLE
[OBSDEF-5967] storageserver config and rbac changes

### DIFF
--- a/ecs-cluster/svc-configs/storageserver/storageserver.conf
+++ b/ecs-cluster/svc-configs/storageserver/storageserver.conf
@@ -3,4 +3,6 @@ logRotationSize=52428800
 maxLogSize=104857600
 partitionroot=/data/storageserver
 verifyPartUuid=false
-useFabric=false
+agentUrlEndPoint=127.0.0.1:9240
+useFabric=true
+keyStore=""


### PR DESCRIPTION
* config directs storageserver to get disk information via Fabric Agent REST API
* storageserver pod gets right to watch pvcs
