### PR TITLE
[OBSDEF-5452] adding RBAC for baremetal-csi resource access to graphql

### DIFF
--- a/objectscale-graphql/templates/objectscale-admin-cluster-role.yaml
+++ b/objectscale-graphql/templates/objectscale-admin-cluster-role.yaml
@@ -23,6 +23,13 @@ rules:
       - get
       - list
   - apiGroups:
+      - csi-baremetal.dell.com
+    resources:
+      - availablecapacities
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - storage.k8s.io
     resources:
       - storageclasses


### PR DESCRIPTION
## Purpose
[OBSDEF-5452](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-5452)
Added an RBAC for GraphQL to be able to list and get AvailableCapacity CR

## PR checklist
- [x] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
```
Charts:      28 passed, 28 total
Test Suites: 50 passed, 50 total
Tests:       240 passed, 240 total
Snapshot:    0 passed, 0 total
Time:        16.551611445s
```