### PR TITLE
[OBSDEF-7991] Fix SP operator script exexcution 

### DIFF
--- a/ecs-cluster/svc-configs/bk-sp/bk-sp.sh
+++ b/ecs-cluster/svc-configs/bk-sp/bk-sp.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -xe
 
 usage() {

--- a/objectscale-manager/templates/operator-rbac.yaml
+++ b/objectscale-manager/templates/operator-rbac.yaml
@@ -59,6 +59,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/exec
   - services
   - endpoints
   - persistentvolumeclaims


### PR DESCRIPTION
## Purpose
[OBSDEF-7991](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-7991)
Fix BK recovery script and allow sp operator to create pod/exec object

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
Tested on the cluster with the Disk Replacement SP. Recovery is a part of the 'first phase' and it passed.
SP operator log
```
2021-05-14T13:38:43.038Z	INFO	diskreplacement/diskreplacement.go:28	Executing Disk replacement Service Procedure
2021-05-14T14:05:25.685Z	INFO	diskreplacement/diskreplacement.go:28	Executing Disk replacement Service Procedure
2021-05-14T14:05:25.686Z	INFO	diskreplacement/diskreplacement.go:42	Processing 1st phase of DR for PVC index-ecs-cluster-bk-bookie-0
2021-05-14T14:06:34.520Z	INFO	diskreplacement/diskreplacement.go:28	Executing Disk replacement Service Procedure
2021-05-14T14:06:34.522Z	INFO	diskreplacement/diskreplacement.go:42	Processing 1st phase of DR for PVC index-ecs-cluster-bk-bookie-0
2021-05-14T14:06:52.941Z	INFO	diskreplacement/diskreplacement.go:138	Removing failed PVC index-ecs-cluster-bk-bookie-0
2021-05-14T14:06:52.951Z	INFO	diskreplacement/diskreplacement.go:124	Removing pod ecs-cluster-bk-bookie-0
2021-05-14T14:07:22.977Z	INFO	diskreplacement/diskreplacement.go:28	Executing Disk replacement Service Procedure
2021-05-14T14:07:22.979Z	INFO	diskreplacement/diskreplacement.go:45	Processing 2nd phase of DR for PVC index-ecs-cluster-bk-bookie-0
```

SP operator events
```
7m4s        Normal    Found unhealthy PVC                      application/objectscale-manager                           Found unhealthy PVC handlig by SP operator: index-ecs-cluster-bk-bookie-0
6m25s       Normal    Recovery started                         application/objectscale-manager                           Started data recovery of the ecs-cluster-bk-bookie-0 application
5m37s       Normal    Pod for failed PVC removed               application/objectscale-manager                           Pod ecs-cluster-bk-bookie-0 used unhealthy PVC was removed
5m37s       Normal    Failed PVC removed                       application/objectscale-manager                           Unhealthy PVC index-ecs-cluster-bk-bookie-0 was removed
5m37s       Normal    Recovery finished                        application/objectscale-manager                           Finished data recovery of the ecs-cluster-bk-bookie-0 application
5m37s       Normal    Disk Replacement started                 application/objectscale-manager                           Starting replacement of failed PVCs index-ecs-cluster-bk-bookie-0
5m7s        Normal    Disk Replacement finished                application/objectscale-manager                           Finished replacement of failed PVCs index-ecs-cluster-bk-bookie-0

```

