### PR TITLE
[OBSDEF-8341] Install CRD prior to enabling supervisor service on vSphere

### DIFF
--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -43,7 +43,7 @@ EOF
 
 else 
      sed "${sed_inplace[@]}" "s/SERVICE_ID//g" temp_package/yaml/objectscale-manager.yaml
-     actual_crd = $(awk '{printf "%4s%s\n", "", $0}' temp_package/yaml/objectscale-crd.yaml)
+     actual_crd=$(awk '{printf "%4s%s\n", "", $0}' temp_package/yaml/objectscale-crd.yaml)
 fi
 
 cat <<EOT >> temp_package/yaml/${vsphere7_plugin_file}

--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -110,7 +110,7 @@ sed "${sed_inplace[@]}" "s/SERVICE_ID/${service_id}/" temp_package/scripts/deplo
 cat temp_package/yaml/${vsphere7_plugin_file} >> temp_package/scripts/deploy-objectscale-plugin.sh 
 echo "EOF" >> temp_package/scripts/deploy-objectscale-plugin.sh
 
-cat <<'EOF' >> temp_package/scripts/deploy-objectscale-plugin.sh
+cat <<EOF >> temp_package/scripts/deploy-objectscale-plugin.sh
 
 if [ $? -ne 0 ]
 then

--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -28,9 +28,17 @@ then
      sed "${sed_inplace[@]}" "s/SERVICE_ID/-${service_id}/g" temp_package/yaml/objectscale-manager.yaml
 
      extra_crd_install=<<'EOF'
+# manually install CRD because of OBSDEF-8341, also tag text for automation
+echomsg "Manually installing CRD because of non-default service ID ${service_id}"
 cat <<'EOT' | kubectl apply -f - 
 $(cat temp_package/yaml/objectscale-crd.yaml)
 EOT
+
+if [ $? -ne 0 ]
+then
+    echomsg "ERROR unable to apply CRD yaml"
+    exit 1
+fi 
 EOF
 
 else 
@@ -109,6 +117,9 @@ then
     echomsg "ERROR unable to apply Dell EMC ObjectScale plugin"
     exit 1
 fi 
+
+${extra_crd_install}
+
 echo
 echomsg "In vSphere7 UI Navigate to Workload-Cluster > Supervisor Services > Services"
 echomsg "Select Dell EMC ObjectScale then Enable"

--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -34,7 +34,7 @@ cat <<'EOT' | kubectl apply -f -
 $(cat temp_package/yaml/objectscale-crd.yaml)
 EOT
 
-if [ $? -ne 0 ]
+if [ \$? -ne 0 ]
 then
     echomsg "ERROR unable to apply CRD yaml"
     exit 1
@@ -113,7 +113,7 @@ echo "EOF" >> temp_package/scripts/deploy-objectscale-plugin.sh
 
 cat <<EOF >> temp_package/scripts/deploy-objectscale-plugin.sh
 
-if [ $? -ne 0 ]
+if [ \$? -ne 0 ]
 then
     echomsg "ERROR unable to apply Dell EMC ObjectScale plugin"
     exit 1

--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -18,12 +18,24 @@ objs_ver=$(grep appVersion: objectscale-manager/Chart.yaml | sed -e "s/.*: //g")
 
 vsphere7_plugin_file="objectscale-${objs_ver}-vmware-config-map.yaml"
 
+extra_crd_install=""
+actual_crd=""
+
 service_id=$1
 if [ ${service_id} != "objectscale" ]
 then
      label="${label}-${service_id}"
      sed "${sed_inplace[@]}" "s/SERVICE_ID/-${service_id}/g" temp_package/yaml/objectscale-manager.yaml
-else sed "${sed_inplace[@]}" "s/SERVICE_ID//g" temp_package/yaml/objectscale-manager.yaml
+
+     extra_crd_install=<<'EOF'
+cat <<'EOT' | kubectl apply -f - 
+$(cat temp_package/yaml/objectscale-crd.yaml)
+EOT
+EOF
+
+else 
+     sed "${sed_inplace[@]}" "s/SERVICE_ID//g" temp_package/yaml/objectscale-manager.yaml
+     actual_crd = $(awk '{printf "%4s%s\n", "", $0}' temp_package/yaml/objectscale-crd.yaml)
 fi
 
 cat <<EOT >> temp_package/yaml/${vsphere7_plugin_file}
@@ -37,7 +49,7 @@ metadata:
     appplatform.vmware.com/kind: supervisorservice
 data:
   ${service_id}-crd.yaml: |-
-$(awk '{printf "%4s%s\n", "", $0}' temp_package/yaml/objectscale-crd.yaml)
+${actual_crd}
   ${service_id}-operator.yaml: |-
 $(awk '{printf "%4s%s\n", "", $0}' temp_package/yaml/objectscale-manager.yaml)
 $(awk '{printf "%4s%s\n", "", $0}' temp_package/yaml/kahm.yaml)

--- a/vmware/vmware_pack.sh
+++ b/vmware/vmware_pack.sh
@@ -27,7 +27,7 @@ then
      label="${label}-${service_id}"
      sed "${sed_inplace[@]}" "s/SERVICE_ID/-${service_id}/g" temp_package/yaml/objectscale-manager.yaml
 
-     extra_crd_install=<<'EOF'
+     extra_crd_install=$(cat <<EOF
 # manually install CRD because of OBSDEF-8341, also tag text for automation
 echomsg "Manually installing CRD because of non-default service ID ${service_id}"
 cat <<'EOT' | kubectl apply -f - 
@@ -40,6 +40,7 @@ then
     exit 1
 fi 
 EOF
+)
 
 else 
      sed "${sed_inplace[@]}" "s/SERVICE_ID//g" temp_package/yaml/objectscale-manager.yaml
@@ -126,3 +127,4 @@ echomsg "Select Dell EMC ObjectScale then Enable"
 EOF
 
 chmod 700 temp_package/scripts/deploy-objectscale-plugin.sh
+


### PR DESCRIPTION
## Purpose
[OBSDEF-8341](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-8341)

vmware/vmware_pack.sh was changed to create empty crd in configmap if service_id is not equal to "objectscale" (not default).
This is needed to skip crd removal when service is disabled.

Tested both manually and automatically. 
Automation change for skip patch verification if CRD were not installed by plugin was merged.

## PR checklist
- [v] make test passed
- [v] make build passed
- [v] helm install <chart> passed
- [v] vSphere7 make package deployments passed
- [_] helm upgrade <chart> passed (not affected)
- [v] helm test <release_name> passed

## Testing
https://asd-ecs-jenkins.isus.emc.com/jenkins/job/charts-ci-vsph7-large/513/robot/report/log.html