### PR TITLE
[OBSDEF-6288] Remove RFW tag from provision image since it is not used anymore

### DIFF
--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -691,7 +691,7 @@ provision:
   newProvisionAPI: true
   image:
     repository: provision
-    tag: 0.70.0.0-814.7fa7d2fb # rfw-update-this provision-docker-image
+    tag: 0.70.0.0-814.7fa7d2fb
     # pullPolicy: IfNotPresent
 
 # The job will assign new created ss to the sp


### PR DESCRIPTION
## Purpose
[OBSDEF-6288] Remove RFW tag from provision image since it is not used anymore

## PR checklist
- [y] make test passed
- [y] make build passed
- [y] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

