### PR TITLE
[OBSDEF-8124] Use the zk image that supports non-default ns by default

### DIFF
--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -207,7 +207,7 @@ zookeeper:
 
   image:
     repository: zookeeper
-    tag: 0.2.10 # rfw-update-this zookeeper-docker-image
+    tag: 0.2.10-176-09b4041 # rfw-update-this zookeeper-docker-image
     # pullPolicy: IfNotPresent
 
   # Persistent storage options for zookeeper volume requests


### PR DESCRIPTION
## Purpose
[OBSDEF-8124](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-8124)
Use the zk image that supports non-default ns in OpenShift by default

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
The default zk image with the fix that supports non-default ns has been verified correct and workable

