### PR TITLE
[OBSDEF-8171] GraphQL needs secret create perms

### DIFF
--- a/objectscale-graphql/templates/objectscale-admin-cluster-role.yaml
+++ b/objectscale-graphql/templates/objectscale-admin-cluster-role.yaml
@@ -76,10 +76,18 @@ rules:
     resources:
       - namespaces
       - serviceaccounts
-      - secrets
       - resourcequotas
       - configmaps
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create


### PR DESCRIPTION
To create the registry secret in end-user namespaces, the API client
must have permissions to create secrets.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-8171](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-8171)


## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
Docker secret `vsphere-docker-secret` is created successfully in end user namespace.

