### PR TITLE
[OBSDEF-8703]add anti-affinity rules 

### DIFF
--- a/kahm/values.yaml
+++ b/kahm/values.yaml
@@ -109,6 +109,7 @@ postgresql-ha:
     extraVolumeMounts:
       - name: dshm
         mountPath: /dev/shm
+    podAntiAffinityPreset: hard
 
     ## PostgreSQL containers' resource requests and limits
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION

## Purpose
[OBSDEF-8703](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-8703)
to spread the postgresql instances across the nodes
This will insure that the pods are spread across the nodes.

## PR checklist
- [ x] make test passed
- [x] make build passed
- [x ] helm install <chart> passed
- [ x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing


