### PR TITLE
[OBSDEF-3870] Make KAHM only set custom values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,18 +267,25 @@ create-decks-app: create-temp-package
 create-kahm-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;
 	cd kahm; \
-	helm template --show-only templates/kahm-app.yaml kahm ../kahm  -n ${NAMESPACE} \
+	helm template --show-only templates/custom.yaml kahm ../kahm  -n ${NAMESPACE} ${HELM_KAHM_ARGS} \
 	--set global.platform=VMware \
+	--set createkahmappResource=true \
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
 	--set global.registry=${KAHM_REGISTRY} \
 	--set global.registrySecret=${REGISTRYSECRET} \
 	--set storageClassName=${STORAGECLASSNAME} \
 	--set postgresql-ha.persistence.storageClass=${STORAGECLASSNAME} \
-        ${HELM_KAHM_ARGS} \
-	-f values.yaml > ../${TEMP_PACKAGE}/yaml/kahm-app.yaml;
+	-f values.yaml > ./customvalues.yaml;
+	# helm does not template referenced files, so we cannot | toJson a file inline
+	yq eval kahm/customvalues.yaml -j -I 0 > kahm/customvalues.json; \
+	# Build the actual kahm application yaml file to apply
+	cd kahm; \
+	helm template --show-only templates/kahm-app.yaml kahm ../kahm  -n ${NAMESPACE} \
+	-f values.yaml -f customvalues.yaml > ../${TEMP_PACKAGE}/yaml/kahm-app.yaml
 	sed ${SED_INPLACE} 's/createkahmappResource\\":true/createkahmappResource\\":false/g' ${TEMP_PACKAGE}/yaml/kahm-app.yaml && \
 	sed ${SED_INPLACE} 's/app.kubernetes.io\/managed-by: Helm/app.kubernetes.io\/managed-by: nautilus/g' ${TEMP_PACKAGE}/yaml/kahm-app.yaml
-	cat ${TEMP_PACKAGE}/yaml/kahm-app.yaml >> ${TEMP_PACKAGE}/yaml/${KAHM_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/kahm-app.yaml
+	cat ${TEMP_PACKAGE}/yaml/kahm-app.yaml > ${TEMP_PACKAGE}/yaml/${KAHM_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/kahm-app.yaml
+	rm -rf kahm/customvalues.*
 
 create-logging-injector-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;

--- a/Makefile
+++ b/Makefile
@@ -266,8 +266,9 @@ create-decks-app: create-temp-package
 
 create-kahm-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;
+	cp kahm/kahm-custom-values.yaml kahm/templates/; \
 	cd kahm; \
-	helm template --show-only templates/custom.yaml kahm ../kahm  -n ${NAMESPACE} ${HELM_KAHM_ARGS} \
+	helm template --show-only templates/kahm-custom-values.yaml kahm ../kahm  -n ${NAMESPACE} ${HELM_KAHM_ARGS} \
 	--set global.platform=VMware \
 	--set createkahmappResource=true \
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
@@ -280,6 +281,7 @@ create-kahm-app: create-temp-package
 	yq eval kahm/customvalues.yaml -j -I 0 > kahm/customvalues.json; \
 	# Build the actual kahm application yaml file to apply
 	cd kahm; \
+	rm -rf templates/kahm-custom-values.yaml; \
 	helm template --show-only templates/kahm-app.yaml kahm ../kahm  -n ${NAMESPACE} \
 	-f values.yaml -f customvalues.yaml > ../${TEMP_PACKAGE}/yaml/kahm-app.yaml
 	sed ${SED_INPLACE} 's/createkahmappResource\\":true/createkahmappResource\\":false/g' ${TEMP_PACKAGE}/yaml/kahm-app.yaml && \

--- a/kahm/kahm-custom-values.yaml
+++ b/kahm/kahm-custom-values.yaml
@@ -1,3 +1,4 @@
+---
 global:
   registrySecret: {{ .Values.global.registrySecret }}
 

--- a/kahm/templates/custom.yaml
+++ b/kahm/templates/custom.yaml
@@ -1,0 +1,16 @@
+global:
+  registrySecret: {{ .Values.global.registrySecret }}
+
+  registry: {{ .Values.global.registry }}
+
+  watchAllNamespaces: {{ .Values.global.watchAllNamespaces }}
+
+  platform: {{ .Values.global.platform }}
+
+storageClassName: {{ .Values.storageClassName }}
+
+postgresql-ha:
+  persistence:
+    storageClass: {{ index .Values "postgresql-ha" "persistence" "storageClass" }}
+
+createkahmappResource: {{ .Values.createkahmappResource }}

--- a/kahm/templates/kahm-app.yaml
+++ b/kahm/templates/kahm-app.yaml
@@ -17,7 +17,7 @@ metadata:
     nautilus.dellemc.com/run-level: "12"
     nautilus.dellemc.com/chart-name: {{.Chart.Name}}
     nautilus.dellemc.com/chart-version: {{ .Chart.Version }}
-    nautilus.dellemc.com/chart-values: {{ .Values | toJson | quote }}
+    nautilus.dellemc.com/chart-values: {{ .Files.Get "customvalues.json" | toJson }}
 spec:
   selector:
     matchLabels:

--- a/kahm/templates/kahm-app.yaml
+++ b/kahm/templates/kahm-app.yaml
@@ -17,7 +17,12 @@ metadata:
     nautilus.dellemc.com/run-level: "12"
     nautilus.dellemc.com/chart-name: {{.Chart.Name}}
     nautilus.dellemc.com/chart-version: {{ .Chart.Version }}
+    {{- if eq .Values.global.platform "VMware" }}
     nautilus.dellemc.com/chart-values: {{ .Files.Get "customvalues.json" | toJson }}
+    {{- else }}
+    nautilus.dellemc.com/chart-values: {{ .Values | toJson | quote }}
+    {{- end }}
+
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Currently we build the chart values annotation by transforming the
*entire* .Values file into json, which outputs all settings including
ones that we do not pass in. This makes it impossible to pick out
specific settings and only propagate those during an upgrade.
The default values should be enough to bring up a component, and we only
need to keep track of a small subset that must be kept over an upgrade.
Doing the install this way lets us upgrade KAHM by only changing the
main chart-version annotation, and the rest of the subcharts and values
will be automatically updated from the new chart version.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-3870](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-3870)

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
Applying the yaml file brings up kahm, updating the chart version upgrades the component and brings in new sub-components automatically.

