### PR TITLE
[OBSDEF-6997] Add support for logging injection in Object Control Service pod

### DIFF
--- a/ecs-cluster/Chart.yaml
+++ b/ecs-cluster/Chart.yaml
@@ -22,3 +22,6 @@ dependencies:
   - name: common-lib
     version: 0.74.0
     repository: file://../common-lib
+  - name: common-monitoring-lib
+    version: 3.7.0-1218.4ad2f6c0
+    repository: https://asdrepo.isus.emc.com/artifactory/objectscale-helm-build/

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -687,6 +687,20 @@ spec:
 {{- else }}
       pullPolicy: {{ .Values.pullPolicy }}
 {{- end }}
+{{- if .Values.control.log }}
+    pod:
+      labels:
+        objectscale.dellemc.com/logging-inject: true
+        app.kubernetes.io/namespace: {{ .Release.Namespace }}
+      annotations:
+        objectscale.dellemc.com/logging-release-name: {{ .Release.Name }}
+    volumes:
+      - name: {{ .Values.control.log.name }}
+        emptyDir: {{ .Values.control.log.emptyDir }}
+    volumeMounts:
+      - name: {{ .Values.control.log.mountName }}
+        mountPath: {{ .Values.control.log.mountPath }}
+{{- end }}
 
   s3:
 {{ include "datasvc-lib.common-labels" . | indent 4 }}

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -624,6 +624,13 @@ control:
     tag: # rfw-update-this object-control-docker-image, non-component-version
     # pullPolicy: IfNotPresent
 
+  # Log files information used for object control service logging injection
+  log:
+    name: log
+    emptyDir: {}
+    mountName: log
+    mountPath: /var/log
+
 # The managementGateway configuration specification
 managementGateway:
   # Override the number of managementGateway replicas to run with the the deployment


### PR DESCRIPTION
## Purpose
[OBSDEF-6997](https://jira.cec.lab.emc.com/browse/OBSDEF-6997)
Changes in this PR:

- '**common-monitoring-lib**' dependency added for _ecs-cluster_ chart
- labels and annotations needed for logging injection in _ObjControlSvc_ pod added

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed

## Testing
_Paste the output of your helm install/vSphere7 deployment testing here_

