### PR TITLE
[OBSDEF-8955] Add DECKS upgrade support & custom settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,14 +259,14 @@ create-decks-app: create-temp-package
 	--set global.registry=${DECKS_REGISTRY} \
 	--set global.registrySecret=${REGISTRYSECRET} \
 	--set decks-support-store.persistentVolume.storageClassName=${STORAGECLASSNAME} \
-	-f values.yaml >  ./customvalues.yaml;
+	-f values.yaml >  ./custom-values.yaml;
 	# helm does not template referenced files, so we cannot | toJson a file inline
-	yq eval decks/customvalues.yaml -j -I 0 > decks/customvalues.json; \
+	yq eval decks/custom-values.yaml -j -I 0 > decks/custom-values.json; \
 	# Build the actual decks application yaml file to apply
 	cd decks; \
 	rm -rf templates/decks-custom-values.yaml; \
 	helm template --show-only templates/decks-app.yaml decks ../decks  -n ${NAMESPACE} \
-	-f values.yaml -f customvalues.yaml > ../${TEMP_PACKAGE}/yaml/decks-app.yaml
+	-f values.yaml -f custom-values.yaml > ../${TEMP_PACKAGE}/yaml/decks-app.yaml
 	sed ${SED_INPLACE} 's/createdecksappResource\\":true/createdecksappResource\\":false/g' ${TEMP_PACKAGE}/yaml/decks-app.yaml && \
 	sed ${SED_INPLACE} 's/app.kubernetes.io\/managed-by: Helm/app.kubernetes.io\/managed-by: nautilus/g' ${TEMP_PACKAGE}/yaml/decks-app.yaml
 	cat ${TEMP_PACKAGE}/yaml/decks-app.yaml > ${TEMP_PACKAGE}/yaml/${DECKS_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/decks-app.yaml

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ create-decks-app: create-temp-package
 	sed ${SED_INPLACE} 's/createdecksappResource\\":true/createdecksappResource\\":false/g' ${TEMP_PACKAGE}/yaml/decks-app.yaml && \
 	sed ${SED_INPLACE} 's/app.kubernetes.io\/managed-by: Helm/app.kubernetes.io\/managed-by: nautilus/g' ${TEMP_PACKAGE}/yaml/decks-app.yaml
 	cat ${TEMP_PACKAGE}/yaml/decks-app.yaml > ${TEMP_PACKAGE}/yaml/${DECKS_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/decks-app.yaml
-	rm -rf decks/customvalues.*
+	rm -rf decks/custom-values.*
 
 create-kahm-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;

--- a/Makefile
+++ b/Makefile
@@ -251,18 +251,26 @@ create-vsphere-templates: create-temp-package
 
 create-decks-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;
+	cp decks/decks-custom-values.yaml decks/templates/; \
 	cd decks; \
-	helm template --show-only templates/decks-app.yaml decks ../decks  -n ${NAMESPACE} \
+	helm template --show-only templates/decks-custom-values.yaml decks ../decks  -n ${NAMESPACE} ${HELM_DECKS_ARGS} ${HELM_DECKS_SUPPORT_STORE_ARGS} \
 	--set global.platform=VMware \
 	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
 	--set global.registry=${DECKS_REGISTRY} \
 	--set global.registrySecret=${REGISTRYSECRET} \
 	--set decks-support-store.persistentVolume.storageClassName=${STORAGECLASSNAME} \
-        ${HELM_DECKS_ARGS} ${HELM_DECKS_SUPPORT_STORE_ARGS} \
-	-f values.yaml > ../${TEMP_PACKAGE}/yaml/decks-app.yaml;
+	-f values.yaml >  ./customvalues.yaml;
+	# helm does not template referenced files, so we cannot | toJson a file inline
+	yq eval decks/customvalues.yaml -j -I 0 > decks/customvalues.json; \
+	# Build the actual decks application yaml file to apply
+	cd decks; \
+	rm -rf templates/decks-custom-values.yaml; \
+	helm template --show-only templates/decks-app.yaml decks ../decks  -n ${NAMESPACE} \
+	-f values.yaml -f customvalues.yaml > ../${TEMP_PACKAGE}/yaml/decks-app.yaml
 	sed ${SED_INPLACE} 's/createdecksappResource\\":true/createdecksappResource\\":false/g' ${TEMP_PACKAGE}/yaml/decks-app.yaml && \
 	sed ${SED_INPLACE} 's/app.kubernetes.io\/managed-by: Helm/app.kubernetes.io\/managed-by: nautilus/g' ${TEMP_PACKAGE}/yaml/decks-app.yaml
-	cat ${TEMP_PACKAGE}/yaml/decks-app.yaml >> ${TEMP_PACKAGE}/yaml/${DECKS_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/decks-app.yaml
+	cat ${TEMP_PACKAGE}/yaml/decks-app.yaml > ${TEMP_PACKAGE}/yaml/${DECKS_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/decks-app.yaml
+	rm -rf decks/customvalues.*
 
 create-kahm-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;

--- a/decks/decks-custom-values.yaml
+++ b/decks/decks-custom-values.yaml
@@ -1,0 +1,17 @@
+---
+global:
+  registrySecret: {{ .Values.global.registrySecret }}
+
+  registry: {{ .Values.global.registry }}
+
+  watchAllNamespaces: {{ .Values.global.watchAllNamespaces }}
+
+  platform: {{ .Values.global.platform }}
+
+storageClassName: {{ .Values.storageClassName }}
+
+decks-support-store:
+  persistentVolume:
+    storageClassName: {{ index .Values "decks-support-store" "persistentVolume" "storageClassName" }}
+
+createdecksappResource: {{ .Values.createdecksappResource }}

--- a/decks/templates/decks-app.yaml
+++ b/decks/templates/decks-app.yaml
@@ -17,7 +17,11 @@ metadata:
     nautilus.dellemc.com/run-level: "15"
     nautilus.dellemc.com/chart-name: {{.Chart.Name}}
     nautilus.dellemc.com/chart-version: {{ .Chart.Version }}
+    {{- if eq .Values.global.platform "VMware" }}
+    nautilus.dellemc.com/chart-values: {{ .Files.Get "customvalues.json" | toJson }}
+    {{- else }}
     nautilus.dellemc.com/chart-values: {{ .Values | toJson | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/decks/templates/decks-app.yaml
+++ b/decks/templates/decks-app.yaml
@@ -18,7 +18,7 @@ metadata:
     nautilus.dellemc.com/chart-name: {{.Chart.Name}}
     nautilus.dellemc.com/chart-version: {{ .Chart.Version }}
     {{- if eq .Values.global.platform "VMware" }}
-    nautilus.dellemc.com/chart-values: {{ .Files.Get "customvalues.json" | toJson }}
+    nautilus.dellemc.com/chart-values: {{ .Files.Get "custom-values.json" | toJson }}
     {{- else }}
     nautilus.dellemc.com/chart-values: {{ .Values | toJson | quote }}
     {{- end }}


### PR DESCRIPTION
Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [x] helm upgrade <chart> passed
- [] helm test <release_name> passed

## Testing
Tested **both** helm install and application only install (letting install controller do the install)
```
decks-889f76cbd-86q6w                                             1/1     Running     0          19s
decks-support-store-84f8455b44-565ff                              1/1     Running     0          20s
```
both come up and the PVC for support store binds correctly.

**note** that the weird double copy/rm/transformation are because Helm is painful to convince to make templates. If the template file is in /templates (which is must be in) then it *has* to have a Kind and Version for `helm install ..` to work, but we do not have a kind for the custom values they are just an ease-of-use .values file, and we are using helm's go templating to auto-generate the values based on --set cmds for make package. Splitting up the values this way and only copying them in when we need to templatize lets us keep both helm install and make package installs working without conflicts.

