### PR TITLE
[OBSDEF-9082]-Fix for the defect OBSDEF-9082 - Replicasets not coming in Ready state intermittantly

### DIFF
--- a/objectscale-portal/templates/objectscale-portal-deployment.yaml
+++ b/objectscale-portal/templates/objectscale-portal-deployment.yaml
@@ -34,7 +34,6 @@ spec:
         release: {{ .Release.Name}}
         operator: objectscale-operator
         product: objectscale
-{{ include "common-monitoring-lib.logging-inject-labels" . | indent 8 }}
 {{ include "common-lib.labels-sp-integrated-all" . | indent 8}}
       annotations:
 {{ include "common-lib.vsphere-emm-integrated_annotation" . | indent 8}}

--- a/objectscale-portal/values.yaml
+++ b/objectscale-portal/values.yaml
@@ -36,9 +36,6 @@ global:
   # Enable log forwarding to central objectscale rsyslog
   rsyslog_enabled: true
 
-  # Enable integration logging framework
-  logging_injection_enabled: true
-
 # The default docker tag and pull policy for objectscale-portal and other containers
 tag: 0.74.0
 pullPolicy: IfNotPresent


### PR DESCRIPTION
## Purpose
[OBSDEF-9082](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9082)
Updated the rsyslog configurations on objectscale-portal

## PR checklist
- [ ] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

