### PR TITLE
[OBSDEF-8172] Add fabric proxy rbac for enduser namespaces

### DIFF
--- a/ecs-cluster/templates/fabric-proxy-api-token.yaml
+++ b/ecs-cluster/templates/fabric-proxy-api-token.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-fabric-proxy-api-token
+  annotations:
+    kubernetes.io/service-account.name: {{ .Release.Name  }}-fabric-proxy
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.tag }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    product: objectscale
+    release: {{ .Release.Name  }}
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/service-account-token

--- a/ecs-cluster/templates/fabric-proxy-rbac.yaml
+++ b/ecs-cluster/templates/fabric-proxy-rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-fabric-proxy
+  namespace: {{ .Release.Namespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-fabric-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-fabric-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-fabric-proxy
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-fabric-proxy
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Installing an objectstore in an enduser namespace breaks fabric proxy
because it does not have the permissions to get/list pods. We do not
want to enabled the permissions on the default service account (the
default sa attached to init containers), so we need to create our own.
Init containers cannot have separate serviceaccounts than the host Pod,
but we can create a custom API token and mount it as one in the init
container. This lets us keep a separation of privilege between the init
container and other Pod containers.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-8172](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-8172)
Related operator PR: https://eos2git.cec.lab.emc.com/ECS/ecs-flex-operator/pull/431

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
*Testing is ongoing for end user namespace to confirm this is all that is needed*

_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

