### PR TITLE
[OBSDEF-9141] Make objectscale-manager upgradeable

### DIFF
--- a/objectscale-manager/objectscale-manager-custom-values.yaml
+++ b/objectscale-manager/objectscale-manager-custom-values.yaml
@@ -1,0 +1,40 @@
+---
+global:
+  registrySecret: {{ .Values.global.registrySecret }}
+
+  registry: {{ .Values.global.registry }}
+
+  watchAllNamespaces: {{ .Values.global.watchAllNamespaces }}
+
+  platform: {{ .Values.global.platform }}
+
+  storageClassName: {{ .Values.global.storageClassName }}
+
+  monitoring_registry: {{ .Values.global.monitoring_registry }}
+
+  monitoring:
+    enabled: {{ .Values.global.monitoring.enabled }}
+
+hooks:
+  registry: {{ .Values.hooks.registry }}
+
+federation:
+  enabled: {{ .Values.federation.enabled }}
+
+ecs-monitoring:
+  influxdb:
+    persistence:
+      storageClassName: {{ index .Values "ecs-monitoring" "influxdb" "persistence" "storageClassName" }}
+
+objectscale-monitoring:
+  influxdb:
+    persistence:
+      storageClassName: {{ index .Values "objectscale-monitoring" "influxdb" "persistence" "storageClassName" }}
+  rsyslog:
+    persistence:
+      storageClassName: {{ index .Values "objectscale-monitoring" "rsyslog" "persistence" "storageClassName" }}
+
+objectscale-gateway:
+  enabled: {{ index .Values "objectscale-gateway" "enabled" }}
+
+createApplicationResource: {{ .Values.createApplicationResource }}

--- a/objectscale-manager/templates/objectscale-manager-app.yaml
+++ b/objectscale-manager/templates/objectscale-manager-app.yaml
@@ -18,7 +18,11 @@ metadata:
     nautilus.dellemc.com/run-level: "10"
     nautilus.dellemc.com/chart-name: objectscale-manager
     nautilus.dellemc.com/chart-version: {{ .Chart.Version }}
+    {{- if eq .Values.global.platform "VMware" }}
+    nautilus.dellemc.com/chart-values: {{ .Files.Get "customvalues.json" | toJson }}
+    {{- else }}
     nautilus.dellemc.com/chart-values: {{ .Values | toJson | quote }}
+    {{- end }}
 spec:
   assemblyPhase: Pending
   selector:


### PR DESCRIPTION
Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-nnnn](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-nnnn)
_List the changes for this PR_

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
```
objectscale-manager-alerts-84896c89df-k25d4                       4/4     Running          0          17m
objectscale-manager-bookkeeper-operator-78679c5d6b-ft5n9          2/2     Running          0          17m
objectscale-manager-fluxd-7dd95687f4-swsj7                        3/3     Running          0          17m
objectscale-manager-grafana-698f6c77c7-m8rlv                      5/5     Running          0          17m
objectscale-manager-influxdb-0                                    5/5     Running          0          16m
objectscale-manager-influxdb-1                                    5/5     Running          0          16m
objectscale-manager-influxdb-2                                    5/5     Running          0          16m
objectscale-manager-influxdb-operator-54d5b4d9b4-8t2hr            1/1     Running          0          17m
objectscale-manager-pravega-operator-5db5bcfc66-g5zrd             2/2     Running          0          17m
objectscale-manager-rsyslog-0                                     3/3     Running          0          16m
objectscale-manager-rsyslog-1                                     3/3     Running          0          16m
objectscale-manager-rsyslog-2                                     3/3     Running          0          16m
objectscale-manager-rsyslog-3                                     3/3     Running          0          16m
objectscale-manager-rsyslog-4                                     3/3     Running          0          16m
objectscale-manager-service-pod-f6465f696-tsm5g                   1/1     Running          0          17m
objectscale-manager-statefuldaemonset-operator-64fcf75987-9nhdv   1/1     Running          0          17m
objectscale-manager-telegraf-8769b8f6b-r648s                      3/3     Running          0          17m
objectscale-manager-throttler-5f94dd489d-g2gdh                    2/2     Running          0          17m
```

helm:
```
objectscale-manager     dellemc-global2-domain-c10      1               2021-06-15 00:22:01.932666751 +0000 UTC deployed        objectscale-manager-0.75.0  0.75.0     
```



