### PR TITLE
[OBSDEF-9175] dcm encryption key

### DIFF
--- a/objectscale-dcm/templates/deployment.yaml
+++ b/objectscale-dcm/templates/deployment.yaml
@@ -67,10 +67,16 @@ spec:
             - name: config
               mountPath: /opt/storageos/conf/dcm-log4j2.xml
               subPath: dcm-log4j2.xml
+            - name: encryptionkey
+              mountPath: /opt/secure/encryptionkey
+              readOnly: true
       volumes:
         - name: log
           emptyDir: {}
         - name: config
           configMap:
             name: dcm-log-config
+        - name: encryptionkey
+          secret:
+            secretName: {{ .Release.Name }}-dcm-encryption-key
 

--- a/objectscale-dcm/templates/encryption-key.yaml
+++ b/objectscale-dcm/templates/encryption-key.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-dcm-encryption-key
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    app.kubernetes.io/name: {{.Release.Name}}
+    app.kubernetes.io/version: {{.Values.tag}}
+    app.kubernetes.io/instance: {{.Release.Name}}
+    app.kubernetes.io/managed-by: {{.Release.Service}}
+    helm.sh/chart: {{.Chart.Name}}-{{.Chart.Version | replace "+" "_"}}
+    product: objectscale
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace}}
+stringData:
+  enckey: {{ randAlphaNum 32 | lower | b64enc }}
+type: Opaque


### PR DESCRIPTION
## Purpose
[OBSDEF-9175](https://jira.cec.lab.emc.com/browse/OBSDEF-9175)
_add secret key generation for dcm_

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/194/

_Paste the output of your helm install/vSphere7 deployment testing here_


Tests output:
```
[root@localhost:~/0.71.2/charts(bugfix-OBSDEF-9175-dcm-enc-keys)]$ make test
helm version
version.BuildInfo{Version:"v3.6+unreleased", GitCommit:"3e1da5f39c512407ec64015437cfd1d3ece626c6", GitTreeState:"clean", GoVersion:"go1.14.2"}
yamllint --version
yamllint 1.20.0
helm lint common-lib ecs-cluster objectscale-manager mongoose zookeeper-operator atlas-operator decks kahm dks-testapp fio-test sonobuoy dellemc-license service-pod helm-controller objectscale-graphql objectscale-vsphere objectscale-portal objectscale-gateway objectscale-iam pravega-operator bookkeeper-operator supportassist decks-support-store statefuldaemonset-operator influxdb-operator federation logging-injector objectscale-dcm --set product=objectscale --set global.product=objectscale
engine.go:159: [INFO] Missing required value: target.accessKey is required
engine.go:159: [INFO] Missing required value: .target.secretKey is required
engine.go:159: [INFO] Missing required value: target.addresses is required
engine.go:159: [INFO] Missing required value: target.port is required
engine.go:159: [INFO] Missing required value: SupportAssist Access Key must be specified
engine.go:159: [INFO] Missing required value: SupportAssist PIN must be specified
engine.go:159: [INFO] Missing required value: productVersion must be specified
engine.go:159: [INFO] Missing required value: siteID must be specified
==> Linting common-lib
[INFO] Chart.yaml: icon is recommended
==> Linting ecs-cluster
==> Linting objectscale-manager
==> Linting mongoose
==> Linting zookeeper-operator
==> Linting atlas-operator
[INFO] Chart.yaml: icon is recommended
==> Linting decks
==> Linting kahm
==> Linting dks-testapp
[INFO] Chart.yaml: icon is recommended
==> Linting fio-test
==> Linting sonobuoy
==> Linting dellemc-license
[INFO] Chart.yaml: icon is recommended
==> Linting service-pod
==> Linting helm-controller
[INFO] Chart.yaml: icon is recommended
==> Linting objectscale-graphql
[INFO] Chart.yaml: icon is recommended
==> Linting objectscale-vsphere
[INFO] Chart.yaml: icon is recommended
==> Linting objectscale-portal
[INFO] Chart.yaml: icon is recommended
==> Linting objectscale-gateway
==> Linting objectscale-iam
==> Linting pravega-operator
==> Linting bookkeeper-operator
==> Linting supportassist
==> Linting decks-support-store
==> Linting statefuldaemonset-operator
[INFO] Chart.yaml: icon is recommended
==> Linting influxdb-operator
[INFO] Chart.yaml: icon is recommended
==> Linting federation
==> Linting logging-injector
[INFO] Chart.yaml: icon is recommended
==> Linting objectscale-dcm
28 chart(s) linted, 0 chart(s) failed
yamllint -c .yamllint.yml */Chart.yaml */values.yaml
ecs-cluster/values.yaml
  123:1     warning  comment not indented like content  (comments-indentation)
  127:1     warning  comment not indented like content  (comments-indentation)
  133:1     warning  comment not indented like content  (comments-indentation)
  166:1     warning  comment not indented like content  (comments-indentation)
  581:5     warning  comment not indented like content  (comments-indentation)
kahm/values.yaml
  55:3      warning  comment not indented like content  (comments-indentation)
  58:3      warning  comment not indented like content  (comments-indentation)
  121:5     warning  comment not indented like content  (comments-indentation)
  131:3     warning  comment not indented like content  (comments-indentation)
  138:3     warning  comment not indented like content  (comments-indentation)
  147:5     warning  comment not indented like content  (comments-indentation)
objectscale-dcm/values.yaml
  37:3      warning  comment not indented like content  (comments-indentation)
objectscale-gateway/values.yaml
  15:6      warning  missing starting space in comment  (comments)
  30:7      warning  comment not indented like content  (comments-indentation)
  75:7      warning  comment not indented like content  (comments-indentation)
objectscale-iam/values.yaml
  51:3      warning  comment not indented like content  (comments-indentation)
objectscale-portal/values.yaml
  34:4      warning  missing starting space in comment  (comments)
yamllint -c .yamllint.yml -s .yamllint.yml .travis.yml
helm unittest common-lib ecs-cluster objectscale-manager mongoose zookeeper-operator atlas-operator decks kahm dks-testapp fio-test sonobuoy dellemc-license service-pod helm-controller objectscale-graphql objectscale-vsphere objectscale-portal objectscale-gateway objectscale-iam pravega-operator bookkeeper-operator supportassist decks-support-store statefuldaemonset-operator influxdb-operator federation logging-injector objectscale-dcm
### Chart [ common-lib ] common-lib
### Chart [ ecs-cluster ] ecs-cluster
 PASS  test ecs-cluster resource	ecs-cluster/tests/ecs_cluster_test.yaml
 PASS  test ecs-cluster resource	ecs-cluster/tests/initial_user_secret_test.yaml
 PASS  test ecs-cluster resource	ecs-cluster/tests/objectstore_rbac_test.yaml
 PASS  test svc logs	ecs-cluster/tests/svc_log4j2_test.yaml
### Chart [ objectscale-manager ] objectscale-manager
 PASS  test objectscale cluster resources	objectscale-manager/tests/objectscale-cluster-resources_test.yaml
 PASS  test operator	objectscale-manager/tests/operator_test.yaml
 PASS  test rsyslog	objectscale-manager/tests/rsyslog_test.yaml
### Chart [ mongoose ] mongoose
### Chart [ zookeeper-operator ] zookeeper-operator
### Chart [ atlas-operator ] atlas-operator
 PASS  test deployment	atlas-operator/tests/deployment_test.yaml
 PASS  test role binding	atlas-operator/tests/role_binding_test.yaml
 PASS  test role	atlas-operator/tests/role_test.yaml
 PASS  test serviceaccount	atlas-operator/tests/serviceaccount_test.yaml
### Chart [ decks ] decks
 PASS  test decks	decks/tests/decks_test.yaml
### Chart [ kahm ] kahm
### Chart [ dks-testapp ] dks-testapp
### Chart [ fio-test ] fio-test
 PASS  test fio cronjob	fio-test/tests/fio_cronjonb_test.yaml
### Chart [ sonobuoy ] sonobuoy
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_clusterrolebinding_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_cronjob_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_namespace_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_service_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_serviceaccount_test.yaml
 PASS  test sonobuoy	sonobuoy/tests/sonobuoy_clusterrole_test.yaml
### Chart [ dellemc-license ] dellemc-license
### Chart [ service-pod ] service-pod
 PASS  test service-pod deployment	service-pod/tests/deploy_test.yaml
 PASS  test service-pod service	service-pod/tests/service_test.yaml
### Chart [ helm-controller ] helm-controller
 PASS  test deployment resource	helm-controller/tests/rest_credentials_secret_test.yaml
 PASS  test deployment resource	helm-controller/tests/service_test.yaml
 PASS  test deployment resource	helm-controller/tests/deployment_test.yaml
### Chart [ objectscale-graphql ] objectscale-graphql
 PASS  test api role	objectscale-graphql/tests/objectscale_admin_clusterrole_test.yaml
 PASS  test api role	objectscale-graphql/tests/objectscale_admin_role_test.yaml
 PASS  test objectscale api rbac	objectscale-graphql/tests/objectscale_api_rbac_test.yaml
 PASS  test graphql deployment	objectscale-graphql/tests/graphql_deploy_test.yaml
 PASS  test graphql service	objectscale-graphql/tests/graphql_service_test.yaml
 PASS  test api role	objectscale-graphql/tests/object_store_admin_role_test.yaml
 PASS  test api role	objectscale-graphql/tests/object_store_monitor_role_test.yaml
### Chart [ objectscale-vsphere ] objectscale-vsphere
 PASS  test psp operator	objectscale-vsphere/tests/persistent-services-platform-operator_test.yaml
 PASS  test psp storage policy	objectscale-vsphere/tests/persistent-services-platform-sp-ha_test.yaml
### Chart [ objectscale-portal ] objectscale-portal
### Chart [ objectscale-gateway ] objectscale-gateway
### Chart [ objectscale-iam ] objectscale-iam
 PASS  test iam deployment	objectscale-iam/tests/atlas_test.yaml
 PASS  test iam deployment	objectscale-iam/tests/deployment_test.yaml
### Chart [ pravega-operator ] pravega-operator
### Chart [ bookkeeper-operator ] bookkeeper-operator
### Chart [ supportassist ] supportassist
### Chart [ decks-support-store ] decks-support-store
 PASS  test support store	decks-support-store/tests/support_store_test.yaml
### Chart [ statefuldaemonset-operator ] statefuldaemonset-operator
 PASS  test deployment	statefuldaemonset-operator/tests/deployment_test.yaml
 PASS  test leader role binding	statefuldaemonset-operator/tests/leader_election_role_binding_test.yaml
 PASS  test leader role	statefuldaemonset-operator/tests/leader_election_role_test.yaml
 PASS  test role binding	statefuldaemonset-operator/tests/role_binding_test.yaml
 PASS  test role	statefuldaemonset-operator/tests/role_test.yaml
 PASS  test role	statefuldaemonset-operator/tests/statefuldaemonset_editor_role_test.yaml
 PASS  test role	statefuldaemonset-operator/tests/statefuldaemonset_viewer_role_test.yaml
### Chart [ influxdb-operator ] influxdb-operator
 PASS  test role	influxdb-operator/tests/role_test.yaml
 PASS  test deployment	influxdb-operator/tests/deployment_test.yaml
 PASS  test role	influxdb-operator/tests/influxdb_editor_role_test.yaml
 PASS  test role	influxdb-operator/tests/influxdb_viewer_role_test.yaml
 PASS  test leader role binding	influxdb-operator/tests/leader_election_role_binding_test.yaml
 PASS  test leader role	influxdb-operator/tests/leader_election_role_test.yaml
 PASS  test role binding	influxdb-operator/tests/role_binding_test.yaml
### Chart [ federation ] federation
### Chart [ logging-injector ] logging-injector
### Chart [ objectscale-dcm ] objectscale-dcm
Charts:      28 passed, 28 total
Test Suites: 50 passed, 50 total
Tests:       240 passed, 240 total
Snapshot:    0 passed, 0 total
Time:        55.48442552s
[root@localhost:~/0.71.2/charts(bugfix-OBSDEF-9175-dcm-enc-keys)]$ 
```

dcm deployment:
```
[root@localhost:/workspace/dev-tools/objectscale/deployment(master)]$ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
atlas-operator-6466dc58d9-mfrv6                    1/1     Running   0          6m19s
ecs-manager-bookkeeper-operator-56966b9d75-ndplb   1/1     Running   0          6m18s
ecs-manager-pravega-operator-9496466c9-vpwls       1/1     Running   0          6m19s
ecs-manager-service-pod-d6646f69-g9k2j             1/1     Running   0          6m19s
federation-atlas-0                                 1/1     Running   0          6m16s
fedsvc-6846877dbc-xnl8v                            1/1     Running   0          6m19s
objectscale-dcm-69b86d77b8-gkxwt                   1/1     Running   0          6m19s
objectscale-dcm-atlas-0                            1/1     Running   0          6m15s
objectscale-gateway-9c5f66d75-gn9m9                1/1     Running   0          6m19s
objectscale-iam-5bd895fb97-vprkx                   1/1     Running   0          6m19s
objectscale-iam-atlas-0                            1/1     Running   0          6m15s
objectscale-operator-58fb76cf94-nlzf5              2/2     Running   0          6m19s
zookeeper-operator-5dd5b6dd67-kz8mh                1/1     Running   0          6m19s
[root@localhost:/workspace/dev-tools/objectscale/deployment(master)]$ kubectl exec -ti objectscale-dcm-69b86d77b8-gkxwt bash
bash-4.4# cat /opt/secure/encryptionkey/enckey 
MHFscXVpZ3RyM3pneDZwbDNpZXM3bzB1bnltbXZwamQ=bash-4.4# 
bash-4.4# 
bash-4.4# 
```
