### PR TITLE
[OBSDEF-9302] set fixed dcm atlas replicas and disk resources for raft wal rotation

### DIFF
--- a/objectscale-dcm/templates/atlas_v1beta1_dcmcluster.yaml
+++ b/objectscale-dcm/templates/atlas_v1beta1_dcmcluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "dcm.name" . }}-atlas
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ coalesce .Values.atlas.replicaCount (index (dict "Large" 3) (title .Values.global.performanceProfile)) 1 }}
+  replicas: {{ .Values.atlas.replicaCount }}
   labels:
     release: {{ .Release.Name }}
 {{ include "common-monitoring-lib.logging-inject-labels" . | indent 4 }}

--- a/objectscale-dcm/values.yaml
+++ b/objectscale-dcm/values.yaml
@@ -2,7 +2,6 @@
 tag: 0.75.0
 global:
   registry: emccorp
-  performanceProfile: "Small"
 
 # DCM image configuration
 image:
@@ -33,6 +32,7 @@ atlas:
     repository: atlas
     tag: 1.1.3 # rfw-update-this atlas-docker-image
   persistence:
-    size: 1Gi
+    size: 3Gi
+
   # Define the replica if you want to explicitly set it
-  # replicaCount: 3
+  replicaCount: 3


### PR DESCRIPTION
## Purpose
[OBSDEF-9302](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9302)
Set DCM Atlas replicas to 3 (fixed value)
Set DCM Atlas disk to 3Gi for remote possibility of raft (consensus protocal) wal (write ahead logs) rotation.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_
https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/198/

_Paste the output of your helm install/vSphere7 deployment testing here_
<pre><font color="#D3D7CF"><b>objectscale-dcm-7d86bdccb-gxjhj                    1/1     Running             0          78s</b></font>
<font color="#D3D7CF"><b>objectscale-dcm-atlas-0                            1/1     Running             0          57s</b></font>
<font color="#D3D7CF"><b>objectscale-dcm-atlas-1                            1/1     Running             0          57s</b></font>
<font color="#D3D7CF"><b>objectscale-dcm-atlas-2                            1/1     Running             0          57s</b></font>
</pre>
