### PR TITLE
[OBSDEF-9326] allow KAHM to connect to remote postgres instance in case of the Atlantic platform 

### DIFF
--- a/kahm/templates/postgress-secrets.yaml
+++ b/kahm/templates/postgress-secrets.yaml
@@ -7,15 +7,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  password: {{ default "ChangeMe" .Values.db.postgres.password }}
-  username: {{ default "kahm" .Values.db.postgres.userName }}
-  dbname: {{ default "kahm" .Values.db.postgres.database }}
+  password: {{required "password must be specified" .Values.db.postgres.password}}
+  username: {{ required "username must be specified" .Values.db.postgres.userName }}
+  dbname: {{ required "database must be specified" .Values.db.postgres.database }}
   port: "{{ default 5432 .Values.db.postgres.port }}"
-{{- if .Values.db.postgresHostName }}
+{{- if .Values.db.postgres.hostName }}
   hostname: {{ .Values.db.postgres.hostName }}
-  credentials: host={{ .Values.db.postgres.hostName }} user={{ default "kahm" .Values.db.postgres.userName }} password={{ default "ChangeMe" .Values.db.postgres.password }} dbname={{ default "kahm" .Values.db.postgres.database }} port={{ default 5432 .Values.db.postgres.port }} sslmode=disable
+  credentials: host={{ .Values.db.postgres.hostName }} user={{ .Values.db.postgres.userName }} password={{ .Values.db.postgres.password }} dbname={{ .Values.db.postgres.database }} port={{ default 5432 .Values.db.postgres.port }} sslmode=disable
 {{- else }}
   hostname: {{ .Release.Name }}-postgressql-ha-pgpool
-  credentials: host={{ .Release.Name }}-postgresql-ha-pgpool user={{ default "kahm" .Values.db.postgres.userName }} password={{ default "ChangeMe" .Values.db.postgres.password }} dbname={{ default "kahm" .Values.db.postgres.database }} port={{ default 5432 .Values.db.postgres.port }} sslmode=disable
+  credentials: host={{ .Release.Name }}-postgresql-ha-pgpool user={{ .Values.db.postgres.userName }} password={{ .Values.db.postgres.password }} dbname={{ .Values.db.postgres.database }} port={{ default 5432 .Values.db.postgres.port }} sslmode=disable
 {{- end }}
 {{- end }}


### PR DESCRIPTION
KAHM can disable the local postgres instance and can connect to the centralized postgres database. In order to connect to the remote instance, KAHM needs username, password, dbname, ip and port of the remote postgres db.
There was a bug where hostname wasn't setting properly. 

## Purpose
[OBSDEF-9326](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9326)
_List the changes for this PR_

## PR checklist
- [ x] make test passed
- [ x] make build passed
- [x ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

