### PR TITLE
[OBSDEF-9143] Make logging injector upgradeable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 monitoring/**/*.tgz
 objectscale-charts-package.tgz
 temp_package
+vmware/create-vsphere-app.py

--- a/Makefile
+++ b/Makefile
@@ -305,17 +305,27 @@ create-kahm-app: create-temp-package
 
 create-logging-injector-app: create-temp-package
 	# cd in makefiles spawns a subshell, so continue the command with ;
+	cp logging-injector/logging-injector-custom-values.yaml logging-injector/templates/; \
 	cd logging-injector; \
+	helm template --show-only templates/logging-injector-custom-values.yaml logging-injector ../logging-injector -n ${NAMESPACE} \
+		--set global.platform=VMware \
+		--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
+    	--set global.registry=${REGISTRY} \
+    	--set global.registrySecret=${REGISTRYSECRET} \
+    	--set global.objectscale_release_name=objectscale-manager \
+    	--set global.rsyslog_client_stdout_enabled=${ENABLE_STDOUT_LOGS_COLLECTION} \
+    -f values.yaml > ./customvalues.yaml
+  	# helm does not template referenced files, so we cannot | toJson a file inline
+	yq eval logging-injector/customvalues.yaml -j -I 0 > logging-injector/customvalues.json; \
+	# Build the actual logging injector appication yaml file to apply
+	cd logging-injector; \
+	rm -rf templates/logging-injector-custom-values.yaml; \
 	helm template --show-only templates/logging-injector-app.yaml logging-injector ../logging-injector -n ${NAMESPACE} \
-	--set global.watchAllNamespaces=${WATCH_ALL_NAMESPACES} \
-	--set global.registry=${REGISTRY} \
-	--set global.registrySecret=${REGISTRYSECRET} \
-	--set global.objectscale_release_name=objectscale-manager \
-	--set global.rsyslog_client_stdout_enabled=${ENABLE_STDOUT_LOGS_COLLECTION} \
-	-f values.yaml > ../${TEMP_PACKAGE}/yaml/logging-injector-app.yaml;
+	-f values.yaml -f customvalues.yaml > ../${TEMP_PACKAGE}/yaml/logging-injector-app.yaml;
 	sed ${SED_INPLACE} 's/createApplicationResource\\":true/createApplicationResource\\":false/g' ${TEMP_PACKAGE}/yaml/logging-injector-app.yaml && \
 	sed ${SED_INPLACE} 's/app.kubernetes.io\/managed-by: Helm/app.kubernetes.io\/managed-by: nautilus/g' ${TEMP_PACKAGE}/yaml/logging-injector-app.yaml
 	cat ${TEMP_PACKAGE}/yaml/logging-injector-app.yaml >> ${TEMP_PACKAGE}/yaml/${LOGGING_INJECTOR_MANIFEST} && rm ${TEMP_PACKAGE}/yaml/logging-injector-app.yaml
+	rm -rf logging-injector/customvalues.*
 
 archive-package:
 	tar -zcvf ${PACKAGE_NAME} ${TEMP_PACKAGE}/*

--- a/logging-injector/logging-injector-custom-values.yaml
+++ b/logging-injector/logging-injector-custom-values.yaml
@@ -1,0 +1,15 @@
+---
+global:
+  registrySecret: {{ .Values.global.registrySecret }}
+
+  registry: {{ .Values.global.registry }}
+
+  watchAllNamespaces: {{ .Values.global.watchAllNamespaces }}
+
+  objectscale_release_name: {{ .Values.global.objectscale_release_name }}
+
+  rsyslog_client_stdout_enabled: {{ .Values.global.rsyslog_client_stdout_enabled }}
+
+  platform: {{ .Values.global.platform }}
+
+createApplicationResource: {{ .Values.createApplicationResource }}

--- a/logging-injector/templates/logging-injector-app.yaml
+++ b/logging-injector/templates/logging-injector-app.yaml
@@ -17,7 +17,11 @@ metadata:
     nautilus.dellemc.com/run-level: "9"    # start before objectscale-manager
     nautilus.dellemc.com/chart-name: logging-injector
     nautilus.dellemc.com/chart-version: {{ .Chart.Version }}
+    {{- if eq .Values.global.platform "VMware" }}
+    nautilus.dellemc.com/chart-values: {{ .Files.Get "customvalues.json" | toJson }}
+    {{- else }}
     nautilus.dellemc.com/chart-values: {{ .Values | toJson | quote }}
+  {{- end }}
 spec:
   assemblyPhase: Pending
   selector:

--- a/logging-injector/values.yaml
+++ b/logging-injector/values.yaml
@@ -16,4 +16,7 @@
 #
 # Create an application resource for management using Dell EMC common installer or other application-resource
 # controllers
+global:
+  platform: Default
+
 createApplicationResource: true


### PR DESCRIPTION
Make the vmware logging-injector yaml file only contain the specified
--set values, so upgrades will automatically update default values and
retain specific ones from customvalues.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>

## Purpose
[OBSDEF-nnnn](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-nnnn)
_List the changes for this PR_

## PR checklist
- [x] make test passed
- [x] make build passed
- [] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/212/
