### PR TITLE
[OBSDEF-8062] Add storageserver service account rights to access CSI Bare-Metal volume CRDs

### DIFF
--- a/ecs-cluster/templates/objectstore-rbac.yaml
+++ b/ecs-cluster/templates/objectstore-rbac.yaml
@@ -42,6 +42,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - csi-baremetal.dell.com
+    resources:
+      - volumes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
[OBSDEF-8062] Fabric-proxy running in storagesrver pod needs list, get and watch CSI Bare-Metal volume CRDs to get actual volume health information (in order to provide it to its clients through Fabric Disk REST API)