### PR TITLE
[OBSDEF-9411]Added limits and requests memory for IAM and FEDSVC Atlas pods

### DIFF
--- a/federation/templates/atlas_v1beta1_fedcluster.yaml
+++ b/federation/templates/atlas_v1beta1_fedcluster.yaml
@@ -22,6 +22,11 @@ spec:
       resources:
         requests:
           storage: {{ required "atlas.persistence.size is required" .Values.atlas.persistence.size }}
+  resources:
+    limits:
+      memory: {{ .Values.atlas.resources.limits.memory }}
+    requests:
+      memory: {{ .Values.atlas.resources.requests.memory }}
   labels:
     component: atlas
 {{ include "common-lib.labels-sp-integrated-all" . | indent 4}}

--- a/federation/values.yaml
+++ b/federation/values.yaml
@@ -39,3 +39,10 @@ atlas:
 
   # Replica count for ObjectScale Federation Atlas Cluster
   replicaCount: 3
+
+  # Atlas pods limits and requests memory setting
+  resources:
+    limits:
+      memory: 1000Mi
+    requests:
+      memory: 256Mi

--- a/objectscale-iam/templates/atlas_v1beta1_iamcluster.yaml
+++ b/objectscale-iam/templates/atlas_v1beta1_iamcluster.yaml
@@ -20,6 +20,11 @@ spec:
       resources:
         requests:
           storage: {{ required "atlas.persistence.size is required" .Values.atlas.persistence.size }}
+  resources:
+    limits:
+      memory: {{ .Values.atlas.resources.limits.memory }}
+    requests:
+      memory: {{ .Values.atlas.resources.requests.memory }}
   labels:
     component: atlas
 {{ include "common-lib.labels-sp-integrated-all" . | indent 4}}

--- a/objectscale-iam/values.yaml
+++ b/objectscale-iam/values.yaml
@@ -102,3 +102,10 @@ atlas:
 
   # Replica count for ObjectScale IAM Atlas Cluster
   replicaCount: 3
+
+  # Atlas pods limits and requests memory setting
+  resources:
+    limits:
+      memory: 1000Mi
+    requests:
+      memory: 256Mi


### PR DESCRIPTION
## Purpose
[OBSDEF-9411](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9411)

- Added limits and requests memory for IAM and FEDSVC Atlas pods

## PR checklist
- [ ] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/226/

## Testing
Manual Testing 
```
0:~/EMCECS/charts # k describe po federation-atlas-0 | grep Limits -A3
    Limits:
      memory:  1000Mi
    Requests:
      memory:   256Mi
10:~/EMCECS/charts # 

10:~/EMCECS/charts # k describe po objectscale-iam-atlas-0 | grep Limits -A3
    Limits:
      memory:  1000Mi
    Requests:
      memory:   256Mi

```
