### PR TITLE
[OBSDEF-9512] Fix for generate-issues-events-all script to ignore rules without label

### DIFF
--- a/tools/issues_events_report/issues_events_reporter.py
+++ b/tools/issues_events_report/issues_events_reporter.py
@@ -62,6 +62,8 @@ def parse_rules(tx):
     if 'rules' in dt:
         for rl in dt['rules']:
             for mh in rl['matchon']:
+                if not 'label' in mh:
+                    continue
                 if mh['label'] == 'SymptomID':
                     reg_rule(mh['value'], rl.copy())
                 else:


### PR DESCRIPTION
## Purpose
https://jira.cec.lab.emc.com/browse/OBSDEF-9512

## PR checklist
- [y] make test passed
- [y] make build passed
- [y] make release passed

## Testing
Manual testing that `make generate-issues-events-all` works after `make build`.