### PR TITLE
[OBSDEF-9622] grafana: fix path for token validation

### DIFF
--- a/objectscale-portal/templates/objectscale-portal-configmap.yaml
+++ b/objectscale-portal/templates/objectscale-portal-configmap.yaml
@@ -135,7 +135,7 @@ data:
                 proxy_set_header X-SDS-AUTH-TOKEN $cookie_osauthtoken;
                 proxy_set_header X-ALLOW-ROLES "SYSTEM_ADMIN,SYSTEM_MONITOR";
                 proxy_set_header Content-Length "";
-                proxy_pass http://$fedsvcname:$fedsvcport/mgmt/validate;
+                proxy_pass http://$fedsvcname:$fedsvcport/mgmt/validateToken;
             }
 
             location /invalidate_token_for_grafana {


### PR DESCRIPTION
## Purpose
[OBSDEF-9622](https://jira.cec.lab.emc.com/browse/OBSDEF-9622)

Fixed path for token validation from `validate` to `validateToken`.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/


