### PR TITLE
[OBSDEF-9595] Allow Operator read StorageClass resources

### DIFF
--- a/objectscale-manager/templates/operator-rbac.yaml
+++ b/objectscale-manager/templates/operator-rbac.yaml
@@ -140,6 +140,14 @@ rules:
     - "*"
   verbs:
     - "*"
+- apiGroups:
+    - "storage.k8s.io"
+  resources:
+    - "storageclasses"
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Purpose
It's needed to get storageType parameter when using Baremetal CSI

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [x] helm upgrade <chart> passed
- [x] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/237/