### PR TITLE
[OBSDEF-9519] removed badgerdb PVC when the database is postgres

### DIFF
--- a/kahm/templates/badgerdb-pvc.yaml
+++ b/kahm/templates/badgerdb-pvc.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if eq .Values.db.dbType "BadgerDB" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,3 +19,4 @@ spec:
   resources:
     requests:
       storage: 2Gi
+{{- end }}

--- a/kahm/templates/kahm.yaml
+++ b/kahm/templates/kahm.yaml
@@ -46,9 +46,11 @@ spec:
           name: metrics
         - containerPort: 17999
           name: rest
+{{- if eq .Values.db.dbType "BadgerDB" }}
         volumeMounts:
         - mountPath: /data/db
           name: db
+{{- end }}
         {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -116,7 +118,9 @@ spec:
               key: credentials
 {{- end }}
       restartPolicy: Always
+{{- if eq .Values.db.dbType "BadgerDB" }}
       volumes:
       - name: db
         persistentVolumeClaim:
           claimName: db-kahm-0 
+{{- end }}


### PR DESCRIPTION
## Purpose
[OBSDEF9519n](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9519)
Don't mount PVC volume to the KAHM pod if the underlying DB is Postgres.

## PR checklist
- [ x] make test passed
- [x ] make build passed
- [x ] helm install <chart> passed
- [ x] vSphere7 make package deployments passed
- [x ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
```
vinod@ubuntu:~/go/src/dellcharts/charts$ helm install kahm ./kahm --set db.dbType=BadgerDB --set db.postgres.enable=false -n vinod
NAME: kahm
LAST DEPLOYED: Thu Jul  1 15:34:54 2021
NAMESPACE: vinod
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing kahm. This release is capable of
deploying and upgrading Kubernetes Application Health Managements.


Your release is named kahm.

To install KAHM by using Helm chart, use the helm install command below:

  $ helm install <repository name>/kahm

For more information on the installation and configuration options, see the
README at https://github.com/EMCECS/charts/tree/master/kahm and the
`values.yaml` file at
https://github.com/EMCECS/charts/blob/master/kahm/values.yaml
vinod@ubuntu:~/go/src/dellcharts/charts$ k get pvc -n vinod
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
db-kahm-0   Bound    pvc-43917193-8944-4569-9811-b276e416726b   2Gi        RWO            standard       11s
vinod@ubuntu:~/go/src/dellcharts/charts$ k get pod -n vinod
NAME                    READY   STATUS    RESTARTS   AGE
kahm-6c4c8f4775-5gbch   1/1     Running   0          17s
```
```
vinod@ubuntu:~/go/src/dellcharts/charts$ helm install kahm ./kahm --set  postgresql-ha.postgresql.podAntiAffinityPreset=soft -n vinod
NAME: kahm
LAST DEPLOYED: Thu Jul  1 15:50:41 2021
NAMESPACE: vinod
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing kahm. This release is capable of
deploying and upgrading Kubernetes Application Health Managements.


Your release is named kahm.

To install KAHM by using Helm chart, use the helm install command below:

  $ helm install <repository name>/kahm

For more information on the installation and configuration options, see the
README at https://github.com/EMCECS/charts/tree/master/kahm and the
`values.yaml` file at
https://github.com/EMCECS/charts/blob/master/kahm/values.yaml
vinod@ubuntu:~/go/src/dellcharts/charts$ k get pods -n vinod
NAME                                         READY   STATUS    RESTARTS   AGE
kahm-5959fdf495-8xsch                        1/1     Running   4          114s
kahm-postgresql-ha-pgpool-6f5d79c888-cg7lf   1/1     Running   0          114s
kahm-postgresql-ha-pgpool-6f5d79c888-h29r5   1/1     Running   0          114s
kahm-postgresql-ha-postgresql-0              1/1     Running   0          114s
kahm-postgresql-ha-postgresql-1              1/1     Running   0          114s
kahm-postgresql-ha-postgresql-2              1/1     Running   1          113s
vinod@ubuntu:~/go/src/dellcharts/charts$ k get pvc -n vinod
NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-kahm-postgresql-ha-postgresql-0   Bound    pvc-eb96ec67-bb2d-43e5-a322-6c44cebf5d1e   8Gi        RWO            standard       119s
data-kahm-postgresql-ha-postgresql-1   Bound    pvc-3c905068-825b-4d72-93bd-5d0c912b4f4f   8Gi        RWO            standard       119s
data-kahm-postgresql-ha-postgresql-2   Bound    pvc-c8f372f4-8080-4335-abc3-0cb994a4ef61   8Gi        RWO            standard       119s

```
