### PR TITLE
OBSDEF-9694 - use helm --devel option to pick up latest latest prerelease versions

### DIFF
--- a/scripts/objectscale-install-main.sh
+++ b/scripts/objectscale-install-main.sh
@@ -77,7 +77,7 @@ function parse_set_opts()
 function install_portal() 
 {
     uiStorageClass=${secondaryStorageClassName:-$primaryStorageClassName}
-    cmd="helm install objectscale-ui ${helm_repo}/objectscale-portal $dryrun --set global.platform=$platform,$registry,$regSecret --set global.storageClassName=$uiStorageClass"
+    cmd="helm install objectscale-ui ${helm_repo}/objectscale-portal $dryrun --set global.platform=$platform,$registry,$regSecret --set global.storageClassName=$uiStorageClass --devel"
     echomsg log $cmd
     eval $cmd
     if [ $? -ne 0 ]
@@ -135,7 +135,7 @@ function install_logging_injector()
 		--set useCustomValues=true \
 		--set global.platform=$platform,$registry,$regSecret \
     	--set global.objectscale_release_name=objectscale-manager \
-    	--set global.rsyslog_client_stdout_enabled=false \
+    	--set global.rsyslog_client_stdout_enabled=false --devel \
         -f ./tmp/logging-injector-values.yaml > ./tmp/logging-injector-customvalues.yaml
     if [ $? -ne 0 ]
     then
@@ -151,7 +151,7 @@ function install_logging_injector()
     fi
 
     ## now gen the app resource
-    helm template --show-only templates/logging-injector-app.yaml logging-injector ${helm_repo}/logging-injector  \
+    helm template --show-only templates/logging-injector-app.yaml logging-injector ${helm_repo}/logging-injector --devel \
 	    -f ./tmp/logging-injector-values.yaml -f ./tmp/logging-injector-customvalues.yaml > ./tmp/logging-injector-app.yaml
     if [ $? -ne 0 ]
     then
@@ -186,7 +186,7 @@ function install_kahm()
 		--set useCustomValues=true \
 		--set global.platform=$platform,$registry,$regSecret \
         --set storageClassName=$secondaryStorageClassName \
-        --set postgresql-ha.persistence.storageClass=$secondaryStorageClassName \
+        --set postgresql-ha.persistence.storageClass=$secondaryStorageClassName --devel \
     -f ./tmp/kahm-values.yaml > ./tmp/kahm-customvalues.yaml 
     if [ $? -ne 0 ]
     then
@@ -202,7 +202,7 @@ function install_kahm()
     fi 
 
     ## now gen the app resource
-    helm template --show-only templates/kahm-app.yaml kahm ${helm_repo}/kahm  \
+    helm template --show-only templates/kahm-app.yaml kahm ${helm_repo}/kahm  --devel \
 	    -f ./tmp/kahm-values.yaml -f ./tmp/kahm-customvalues.yaml > ./tmp/kahm-app.yaml
     if [ $? -ne 0 ]
     then
@@ -233,7 +233,7 @@ function install_decks()
 		--set useCustomValues=true \
 		--set global.platform=$platform,$registry,$regSecret \
         --set global.storageClassName=$secondaryStorageClassName \
-       	--set decks-support-store.persistentVolume.storageClassName=$secondaryStorageClassName \
+       	--set decks-support-store.persistentVolume.storageClassName=$secondaryStorageClassName --devel \
     -f ./tmp/decks-values.yaml > ./tmp/decks-customvalues.yaml 
     if [ $? -ne 0 ]
     then
@@ -249,7 +249,7 @@ function install_decks()
     fi 
 
     ## now gen the app resource
-    helm template --show-only templates/decks-app.yaml decks ${helm_repo}/decks  \
+    helm template --show-only templates/decks-app.yaml decks ${helm_repo}/decks  --devel \
 	    -f ./tmp/decks-values.yaml -f ./tmp/decks-customvalues.yaml > ./tmp/decks-app.yaml
     if [ $? -ne 0 ]
     then
@@ -286,7 +286,7 @@ function install_objectscale_manager()
         --set ecs-monitoring.influxdb.persistence.storageClassName=$primaryStorageClassName \
         --set global.monitoring_registry=$registryName \
 		--set objectscale-monitoring.influxdb.persistence.storageClassName=$primaryStorageClassName \
-	    --set objectscale-monitoring.rsyslog.persistence.storageClassName=$secondaryStorageClassName \
+	    --set objectscale-monitoring.rsyslog.persistence.storageClassName=$secondaryStorageClassName --devel \
          -f ./tmp/objectscale-manager-values.yaml > ./tmp/objectscale-manager-customvalues.yaml && sed -i '1,5d' ./tmp/objectscale-manager-customvalues.yaml
     if [ $? -ne 0 ]
     then
@@ -303,7 +303,7 @@ function install_objectscale_manager()
 
     echomsg "Generating $component application resource..."
     ## now gen the app resource
-    helm template --show-only templates/objectscale-manager-app.yaml objectscale-manager ${helm_repo}/objectscale-manager  \
+    helm template --show-only templates/objectscale-manager-app.yaml objectscale-manager ${helm_repo}/objectscale-manager  --devel \
 	    -f ./tmp/objectscale-manager-values.yaml -f ./tmp/objectscale-manager-customvalues.yaml > ./tmp/objectscale-manager-app.yaml
     if [ $? -ne 0 ]
     then


### PR DESCRIPTION
## Purpose
[OBSDEF-9694](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9694)
- Changed all `helm` calls to use the `--devel` option
- - this allows us to get the latest pre-release version `0.77.0-1172` 

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
### openshift red cluster testing:
```
./temp_package/openshift/objectscale-install.sh --set type=install  --set helmrepo=objs --set primaryStorageClassName=csi-baremetal-sc-ssdlvg   --set secondaryStorageClassName=csi-baremetal-sc-hddlvg --set global.registry=asdrepo.isus.emc.com:8099

└─ $ ▶  kubectl get pod
helmNAME                                                              READY   STATUS    RESTARTS   AGE
atlas-operator-9b7496457-8chnt                                    2/2     Running   0          19h
csi-baremetal-controller-cc86d5b99-cj654                          4/4     Running   0          21h
csi-baremetal-node-2kwpn                                          4/4     Running   1          21h
csi-baremetal-node-7sjhn                                          4/4     Running   1          21h
csi-baremetal-node-9zplm                                          4/4     Running   1          21h
csi-baremetal-node-controller-6556f45bcc-9w7z4                    1/1     Running   0          21h
csi-baremetal-node-gzpq5                                          4/4     Running   1          21h
csi-baremetal-node-l9mgq                                          4/4     Running   1          21h
csi-baremetal-node-tsqwj                                          4/4     Running   1          21h
csi-baremetal-node-vwbcb                                          4/4     Running   1          21h
csi-baremetal-node-x97bt                                          4/4     Running   1          21h
csi-baremetal-operator-647c789668-q4pft                           1/1     Running   0          21h
csi-baremetal-se-4w2hs                                            1/1     Running   0          21h
csi-baremetal-se-fwf7x                                            1/1     Running   0          21h
csi-baremetal-se-wbd2d                                            1/1     Running   0          21h
decks-778c769db8-wkdfx                                            1/1     Running   0          19h
decks-support-store-6f5685dc4c-j77dm                              1/1     Running   0          19h
federation-atlas-0                                                2/2     Running   0          19h
federation-atlas-1                                                2/2     Running   0          19h
federation-atlas-2                                                2/2     Running   0          19h
fedsvc-6fdc9566d8-jzcg4                                           2/2     Running   0          19h
fedsvc-6fdc9566d8-xtf8n                                           2/2     Running   0          19h
fedsvc-6fdc9566d8-zp2s2                                           2/2     Running   0          19h
kahm-6687497b88-l9bf4                                             1/1     Running   0          19h
kahm-postgresql-ha-pgpool-ff6ffd865-cbbmk                         1/1     Running   0          19h
kahm-postgresql-ha-pgpool-ff6ffd865-h6sk7                         1/1     Running   0          19h
kahm-postgresql-ha-postgresql-0                                   1/1     Running   0          19h
kahm-postgresql-ha-postgresql-1                                   1/1     Running   1          19h
kahm-postgresql-ha-postgresql-2                                   1/1     Running   1          19h
logging-injector-6fcddd5885-kr4xs                                 2/2     Running   0          19h
objectscale-dcm-6c4c86bc45-gmgsq                                  2/2     Running   0          19h
objectscale-dcm-atlas-0                                           2/2     Running   0          19h
objectscale-dcm-atlas-1                                           2/2     Running   0          19h
objectscale-dcm-atlas-2                                           2/2     Running   0          19h
objectscale-gateway-79fdc999f5-8x6d2                              1/1     Running   0          19h
objectscale-graphql-86b86b6c77-bnqj9                              2/2     Running   0          19h
objectscale-iam-557b7946fc-64wjd                                  2/2     Running   0          19h
objectscale-iam-557b7946fc-6xwf4                                  2/2     Running   0          19h
objectscale-iam-557b7946fc-l8qzs                                  2/2     Running   0          19h
objectscale-iam-atlas-0                                           2/2     Running   0          19h
objectscale-iam-atlas-1                                           2/2     Running   0          19h
objectscale-iam-atlas-2                                           2/2     Running   0          19h
objectscale-install-controller-6f589c6d54-mpbgv                   1/1     Running   0          19h
objectscale-manager-alerts-5796cf9944-qb6zm                       4/4     Running   0          19h
objectscale-manager-bookkeeper-operator-69978c5cb7-jx2kz          2/2     Running   0          19h
objectscale-manager-fluxd-6cdd5458cf-xgvjz                        3/3     Running   0          19h
objectscale-manager-grafana-6b6c77bdcf-ls69t                      5/5     Running   0          19h
objectscale-manager-influxdb-0                                    5/5     Running   0          19h
objectscale-manager-influxdb-1                                    5/5     Running   0          19h
objectscale-manager-influxdb-2                                    5/5     Running   0          19h
objectscale-manager-influxdb-operator-8d879f67b-qbfxt             2/2     Running   0          19h
objectscale-manager-pravega-operator-6fbb848f95-lhtqx             2/2     Running   0          19h
objectscale-manager-rsyslog-0                                     3/3     Running   0          19h
objectscale-manager-rsyslog-1                                     3/3     Running   0          19h
objectscale-manager-rsyslog-2                                     3/3     Running   0          19h
objectscale-manager-rsyslog-3                                     3/3     Running   0          19h
objectscale-manager-rsyslog-4                                     3/3     Running   0          19h
objectscale-manager-rsyslog-5                                     3/3     Running   0          19h
objectscale-manager-rsyslog-6                                     3/3     Running   0          19h
objectscale-manager-rsyslog-7                                     3/3     Running   0          19h
objectscale-manager-service-pod-67b746f695-krqbx                  1/1     Running   0          19h
objectscale-manager-statefuldaemonset-operator-66b4fb7b9f-5xmjm   2/2     Running   0          19h
objectscale-manager-telegraf-c89d8fd98-5564h                      3/3     Running   0          19h
objectscale-manager-throttler-68c64bf4f-g7crm                     2/2     Running   0          19h
objectscale-operator-7c8757cc55-kvl4d                             3/3     Running   0          19h
objectscale-portal-56f694b856-45xmj                               2/2     Running   0          19h
objectscale-portal-56f694b856-b565s                               2/2     Running   0          19h
zookeeper-operator-6858bfcdcf-2twr5                               2/2     Running   0          19h
epavkovi @ ubuntu-07 ~/src/emcecs/charts (bugfix-OBSDEF-9694-helm-install-devel)
└─ $ ▶  helm list 
NAME                  	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                                    	APP VERSION
csi-baremetal         	default  	1       	2021-07-03 02:39:36.043160435 +0000 UTC	deployed	csi-baremetal-deployment-0.2.2-37.3669952	0.2.2      
csi-baremetal-operator	default  	1       	2021-07-03 02:39:23.955433994 +0000 UTC	deployed	csi-baremetal-operator-0.2.2-37.3669952  	0.2.2      
decks                 	default  	1       	2021-07-03 04:17:45.761146186 +0000 UTC	deployed	decks-2.77.0-1172                        	2.77.0-1172
kahm                  	default  	1       	2021-07-03 04:09:55.962267228 +0000 UTC	deployed	kahm-2.77.0-1172                         	2.77.0-1172
logging-injector      	default  	1       	2021-07-03 04:09:47.723181368 +0000 UTC	deployed	logging-injector-0.77.0-1172             	0.77.0-1172
objectscale-manager   	default  	1       	2021-07-03 04:10:17.371704598 +0000 UTC	deployed	objectscale-manager-0.77.0-1172          	0.77.0-1172
objectscale-ui        	default  	1       	2021-07-03 04:09:43.725370966 +0000 UTC	deployed	objectscale-portal-0.77.0-1172           	0.77.0-1172
epavkovi @ ubuntu-07 ~/src/emcecs/charts (bugfix-OBSDEF-9694-helm-install-devel)
└─ $ ▶  kubebectl get app
kubebectl: command not found
epavkovi @ ubuntu-07 ~/src/emcecs/charts (bugfix-OBSDEF-9694-helm-install-devel)
└─ $ ▶  kubectl get app
NAME                     TYPE                  VERSION       OWNER   READY   AGE
decks                    decks                 2.76.0                        19h
kahm                     kahm                  2.76.0                        19h
logging-injector         logging-injector      0.77.0-1172                   19h
objectscale-manager      objectscale-manager   0.76.0                        19h
objectscale-monitoring                                                       19h
```