### PR TITLE
[FABRIC-9269] fix PR validation for charts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,12 @@ pipeline {
 
                 withDockerContainer(image: DOCKER_IMAGE, args: DOCKER_ARGS) {
                     sshagent([GH_CREDS]) {
+
+                        // NOTE this is to fix non-default (not in /usr/bin) location of pip in newer python2.7
+                        sh("sed -i 's/\\(secure_path=\\\"\\)/\\1\\/usr\\/local\\/bin:/' /etc/sudoers")
+                        // remove old version of yq provided by fabric devkit
+                        sh("rm -rf /usr/local/bin/yq")
+
                        sh('''
                             make dep
                             PATH=/tmp:$PATH

--- a/snmp-notifier/Chart.yaml
+++ b/snmp-notifier/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
     url: http://dellemc.com
 dependencies:
   - name: common-lib
-    version: 0.75.0 # no_auto_change__flex_auto_change
+    version: 0.76.0 # no_auto_change__flex_auto_change
     repository: file://../common-lib

--- a/snmp-notifier/values.yaml
+++ b/snmp-notifier/values.yaml
@@ -23,7 +23,7 @@ enabled: true
 # The image configured for snmp notifier
 image:
   repository: snmp-notifier
-  tag: # rfw-update-this snmp-notifier-image
+  tag: 2.76.0 # rfw-update-this snmp-notifier-image
   # pullPolicy: Always
 # the GRPC setting between KAHM and snmp-notifier
 grpc:
@@ -37,7 +37,7 @@ createAppResource: true
 # snmpServer- required field to pass using --set
 snmpServer:
   # snmp server host/ip address - mandatory parameter
-  # host: 10.11.12.13
+  host: 10.11.12.13
   # snmp server port
   port: 162
   # v2c or v3


### PR DESCRIPTION
## Purpose
Update to PR Validation after ECS/infra-devkit/pull/43
The same fix as in ECS/pipelines/pull/956/

Also, updated values.yaml for snmp-notifier to meet values.schema.json to pass `make test`

## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

