### PR TITLE
[OBSDEF-1200]Add support of pravega pod affinity

### DIFF
--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -405,10 +405,12 @@ spec:
       controllerServiceAccountName: {{ .Release.Name }}-pravega
       segmentStoreServiceAccountName: {{ .Release.Name }}-pravega
       {{- if .Values.pravega.controller.affinity }}
-      controllerPodAffinity: {{ toYaml .Values.pravega.controller.affinity | indent 8 }}
+      controllerPodAffinity:
+        {{ toYaml .Values.pravega.controller.affinity | nindent 8 | trim }}
       {{- end }}
       {{- if .Values.pravega.segmentStore.affinity }}
-      segmentStorePodAffinity: {{ toYaml .Values.pravega.segmentStore.affinity | indent 8 }}
+      segmentStorePodAffinity:
+        {{ toYaml .Values.pravega.segmentStore.affinity | nindent 8 | trim }}
       {{- end }}
 
   storageServer:

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -395,9 +395,21 @@ spec:
         {{- if .Values.pravega.options.configMapVolumeMounts }}
         configMapVolumeMounts: {{$.Release.Name}}-prvg-{{ .Values.pravega.options.configMapVolumeMounts }}
         {{- end }}
+        {{- if .Values.pravega.options.controllerPodAntiAffinityType }}
+        controllerPodAntiAffinityType: {{ .Values.pravega.options.controllerPodAntiAffinityType }}
+        {{- end }}
+        {{- if .Values.pravega.options.segmentStorePodAntiAffinityType }}
+        segmentStorePodAntiAffinityType: {{ .Values.pravega.options.segmentStorePodAntiAffinityType }}
+        {{- end }}
       debugLogging: {{ .Values.pravega.debugLogging }}
       controllerServiceAccountName: {{ .Release.Name }}-pravega
       segmentStoreServiceAccountName: {{ .Release.Name }}-pravega
+      {{- if .Values.pravega.controller.affinity }}
+      controllerPodAffinity: {{ toYaml .Values.pravega.controller.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.pravega.segmentStore.affinity }}
+      segmentStorePodAffinity: {{ toYaml .Values.pravega.segmentStore.affinity | indent 8 }}
+      {{- end }}
 
   storageServer:
     serviceAccount: {{ .Release.Name }}-storageserver

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -123,10 +123,12 @@ pravega:
 #    replicas: 1
     service:
       type: ClusterIP
+#    affinity: {}
   segmentStore:
 #    replicas: 1
     service:
       type: ClusterIP
+#    affinity: {}
   debugLogging: false
   externalAccess:
     enabled: false
@@ -136,6 +138,8 @@ pravega:
       influxDBName: "pravega"
     emptyDirVolumeMounts: "heap-dump=/crash-dump,log=/opt/pravega/logs"
     configMapVolumeMounts: "log4j2:logback.xml=/opt/pravega/conf/logback.xml"
+#    controllerPodAntiAffinityType: "required"
+#    segmentStorePodAntiAffinityType: "required"
 #    bookkeeper.write.outstanding.bytes.max: "33554432"
 #    bookkeeper.write.timeout.milliseconds: "60000"
 #    bookkeeper.zk.connect.sessionTimeout.milliseconds: "15000"


### PR DESCRIPTION
## Purpose
[OBSDEF-1200](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-1200)
Add support of pravega pod affinity

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
The pravega pod affinity has been configured via paremeters as expected, with required pod anti-affinity as default

