### PR TITLE
OBSDEF-9984 - openshift install fix creating customvalues for objs-mgr

### DIFF
--- a/scripts/objectscale-install-main.sh
+++ b/scripts/objectscale-install-main.sh
@@ -287,7 +287,7 @@ function install_objectscale_manager()
         --set global.monitoring_registry=$registryName \
 		--set objectscale-monitoring.influxdb.persistence.storageClassName=$primaryStorageClassName \
 	    --set objectscale-monitoring.rsyslog.persistence.storageClassName=$secondaryStorageClassName --devel \
-         -f ./tmp/objectscale-manager-values.yaml > ./tmp/objectscale-manager-customvalues.yaml && sed -i '1,5d' ./tmp/objectscale-manager-customvalues.yaml
+         -f ./tmp/objectscale-manager-values.yaml > ./tmp/objectscale-manager-customvalues.yaml && sed -i -e "/^-/d" -e "/^\#/d" ./tmp/objectscale-manager-customvalues.yaml
     if [ $? -ne 0 ]
     then
         echomsg error "unable to generate $component custom values"


### PR DESCRIPTION
## Purpose
[OBSDEF-9984](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9984)
- properly create custom values for objectscale-manager 

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
### new install:
```
./temp_package/openshift/objectscale-install.sh --set type=install  --set helmrepo=objs --set primaryStorageClassName=csi-baremetal-sc-hddlvg   --set secondaryStorageClassName=csi-baremetal-sc-hddlvg --set global.registry=asdrepo.isus.emc.com:8099
21.07.08 10:14:03 : ==============================================
21.07.08 10:14:03 : ObjectScale install version: 0.76.0
21.07.08 10:14:03 : ==============================================
21.07.08 10:14:03 : Locating kubectl...
21.07.08 10:14:03 : Client Version: v1.16.4
Server Version: v1.19.0+e405995
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.4", GitCommit:"224be7bdce5a9dd0c2fd0d46b83865648e2fe0ba", GitTreeState:"clean", BuildDate:"2019-12-11T12:47:40Z", GoVersion:"go1.12.12", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.0+e405995", GitCommit:"e40599583c035332dc295d9ea2c52e7635d48a6e", GitTreeState:"clean", BuildDate:"2021-02-05T01:23:59Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
W0708 10:14:09.549743 1034417 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
W0708 10:14:11.053223 1034417 warnings.go:70] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
NAME: objectscale-ui
LAST DEPLOYED: Thu Jul  8 10:14:06 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing objectscale-portal. This release provides 
a Dell EMC ObjectScale User Interface (portal)

This release is named objectscale-ui.

1. To get started, read your service account token:

  $ read -r SVCACCOUNT_TOKEN \
        <<< $(kubectl get secret -o jsonpath='{.data.token}' $(kubectl get sa "objectscale-api" -o json | jq -r '.secrets[] | select (.name | test("objectscale-api-token-")).name') | base64 --decode; echo -n " ")

2. Use "kubectl get svc objectscale-portal-external" to obtain the network address of the ObjectScale Portal

   kubectl get svc objectscale-portal-external
   NAME                          TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)          AGE
   objectscale-portal-external   LoadBalancer   172.30.160.33   10.236.228.48   4443:31474/TCP   118s

3. Bring up a browser and connect to the above URL: https://<addr>:4443

4. Then paste this service account token into the ObjectScale Portal login page.

---
21.07.08 10:14:11 : Installing ObjectScale components...
21.07.08 10:14:11 : Applying k8s application crd
customresourcedefinition.apiextensions.k8s.io/applications.app.k8s.io configured
21.07.08 10:14:13 : Installing logging-injector...
application.app.k8s.io/logging-injector created
21.07.08 10:14:15 : Installed logging-injector done
21.07.08 10:14:15 : Install kahm
application.app.k8s.io/kahm created
application.app.k8s.io/decks created
21.07.08 10:14:20 : Installing objectscale-manager
21.07.08 10:14:21 : Generating objectscale-manager install settings...
21.07.08 10:14:31 : Generating objectscale-manager application resource...
application.app.k8s.io/objectscale-manager created
21.07.08 10:14:43 : Installed component: 
21.07.08 10:14:43 : ==============================================
NAME                  	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                                    	APP VERSION
csi-baremetal         	default  	1       	2021-07-03 02:39:36.043160435 +0000 UTC	deployed	csi-baremetal-deployment-0.2.2-37.3669952	0.2.2      
csi-baremetal-operator	default  	1       	2021-07-03 02:39:23.955433994 +0000 UTC	deployed	csi-baremetal-operator-0.2.2-37.3669952  	0.2.2      
logging-injector      	default  	1       	2021-07-08 14:14:15.509956024 +0000 UTC	deployed	logging-injector-0.77.0-1172             	0.77.0-1172
objectscale-ui        	default  	1       	2021-07-08 10:14:06.433167893 -0400 EDT	deployed	objectscale-portal-0.77.0-1172           	0.77.0-1172
21.07.08 10:14:43 : ==============================================
NAME                  TYPE                  VERSION       OWNER   READY   AGE
decks                 decks                 2.76.0                        24s
kahm                  kahm                  2.76.0                        26s
logging-injector      logging-injector      0.77.0-1172                   29s
objectscale-manager   objectscale-manager   0.76.0                        1s
NOTES:

Thank you for installing objectscale-portal. This release provides 
a Dell EMC ObjectScale User Interface (portal)

This release is named objectscale-ui.

1. To get started, read your service account token:

  $ read -r SVCACCOUNT_TOKEN \
        <<< $(kubectl get secret -o jsonpath='{.data.token}' $(kubectl get sa "objectscale-api" -o json | jq -r '.secrets[] | select (.name | test("objectscale-api-token-")).name') | base64 --decode; echo -n " ")

2. Use "kubectl get svc objectscale-portal-external" to obtain the network address of the ObjectScale Portal

   kubectl get svc objectscale-portal-external
   NAME                          TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)          AGE
   objectscale-portal-external   LoadBalancer   172.30.160.33   10.236.228.48   4443:31474/TCP   118s

3. Bring up a browser and connect to the above URL: https://<addr>:4443

4. Then paste this service account token into the ObjectScale Portal login page.

---

21.07.08 10:14:44 : ==============================================

21.07.08 10:14:44 : Please wait a few minutes until all ObjectScale have started
21.07.08 10:14:44 : ==============================================


└─ $ ▶  helm list
NAME                  	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                                    	APP VERSION
csi-baremetal         	default  	1       	2021-07-03 02:39:36.043160435 +0000 UTC	deployed	csi-baremetal-deployment-0.2.2-37.3669952	0.2.2      
csi-baremetal-operator	default  	1       	2021-07-03 02:39:23.955433994 +0000 UTC	deployed	csi-baremetal-operator-0.2.2-37.3669952  	0.2.2      
decks                 	default  	1       	2021-07-08 14:20:07.916160097 +0000 UTC	deployed	decks-2.77.0-1172                        	2.77.0-1172
kahm                  	default  	1       	2021-07-08 14:14:25.788486324 +0000 UTC	deployed	kahm-2.77.0-1172                         	2.77.0-1172
logging-injector      	default  	1       	2021-07-08 14:14:15.509956024 +0000 UTC	deployed	logging-injector-0.77.0-1172             	0.77.0-1172
objectscale-manager   	default  	1       	2021-07-08 14:14:43.492889004 +0000 UTC	deployed	objectscale-manager-0.77.0-1172          	0.77.0-1172
objectscale-ui        	default  	1       	2021-07-08 10:14:06.433167893 -0400 EDT	deployed	objectscale-portal-0.77.0-1172           	0.77.0-1172
```



