### PR TITLE
[OBSDEF-9941] Add status field for ServiceProcedure CRD

### DIFF
--- a/objectscale-manager/crds/dellemc.com_serviceprocedures_crd.yaml
+++ b/objectscale-manager/crds/dellemc.com_serviceprocedures_crd.yaml
@@ -2,12 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprocedures.ecs.dellemc.com
-  labels:
-    app.kubernetes.io/name: objectscale-manager
-    helm.sh/chart: objectscale-manager
-    app.kubernetes.io/component: objectscale-operator
-    app.kubernetes.io/part-of: objectscale-manager
-    app.kubernetes.io/managed-by: nautilus
 spec:
   group: ecs.dellemc.com
   names:
@@ -16,6 +10,15 @@ spec:
     plural: serviceprocedures
     singular: serviceprocedure
   scope: Namespaced
+  additionalPrinterColumns:
+    - name: STATUS
+      type: string
+      description: The status of service procedure
+      JSONPath: .status.reason
+    - description: The creation date
+      JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
   subresources:
     status: {}
   validation:
@@ -49,6 +52,16 @@ spec:
                 uuid:
                   type: string
               type: object
+            podsInfo:
+              items:
+                description: ObjectInfo defines objects name and UUID
+                properties:
+                  name:
+                    type: string
+                  uuid:
+                    type: string
+                type: object
+              type: array
             type:
               type: string
           required:

--- a/objectscale-manager/crds/dellemc.com_serviceprocedures_crd.yaml
+++ b/objectscale-manager/crds/dellemc.com_serviceprocedures_crd.yaml
@@ -2,6 +2,12 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprocedures.ecs.dellemc.com
+  labels:
+    app.kubernetes.io/name: objectscale-manager
+    helm.sh/chart: objectscale-manager
+    app.kubernetes.io/component: objectscale-operator
+    app.kubernetes.io/part-of: objectscale-manager
+    app.kubernetes.io/managed-by: nautilus
 spec:
   group: ecs.dellemc.com
   names:


### PR DESCRIPTION
## Purpose
[OBSDEF-9941](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9941)
_List the changes for this PR_
Cosmetic changes to show ServiceProcedures status and updated CRD's field according to current Go model.

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/252/

## Testing
_Paste URL of charts-custom-ci job here_

Manual testing:
```
$ kubectl get serviceprocedure
NAME                                                    STATUS     AGE
disk-replacement-818d7b26-a1f4-4eed-a4c2-06ff449c079c   Rejected   7m5s
disk-replacement-c6fc1092-789c-4202-9ca0-67a83cf23de7   Rejected   2m41s
```
