### PR TITLE
[OBSDEF-9636] Add right resource labels

### DIFF
--- a/decks/templates/decks.yaml
+++ b/decks/templates/decks.yaml
@@ -5,7 +5,8 @@ metadata:
   name: decks
   namespace: {{.Release.Namespace}}
   labels:
-    app.kubernetes.io/name: "decks"
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     release: {{ .Release.Name }}
     name: decks
 spec:

--- a/kahm/templates/kahm.yaml
+++ b/kahm/templates/kahm.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kahm
   namespace: {{ .Release.Namespace}}
   labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
     release: {{ .Release.Name }}
 spec:
   replicas: 1

--- a/supportassist/templates/supportassist.yaml
+++ b/supportassist/templates/supportassist.yaml
@@ -72,6 +72,7 @@ metadata:
   name: supportassist-{{.Values.product}}
   namespace: {{.Release.namespace}}
   labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: supportassist-{{.Values.product}}-ese
 {{ include "supportassist.labels" . | indent 4 }}
 spec:


### PR DESCRIPTION
The app.kubernetes.io/instance labels **must** be set on all deployments and statefulsets so we can aggregate the application's readiness properly.

Signed-off-by: Tudor Marcu <Tudor.Marcu@emc.com>


## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing


