### PR TITLE
[OBSDEF-10025] Fix the cluster role for graphql

### DIFF
--- a/objectscale-graphql/templates/objectscale-admin-cluster-role.yaml
+++ b/objectscale-graphql/templates/objectscale-admin-cluster-role.yaml
@@ -74,6 +74,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
       - namespaces
       - serviceaccounts
       - resourcequotas


### PR DESCRIPTION
Signed-off-by: Youmin_Han <Youmin_Han@dell.com>

## Purpose
[OBSDEF-10025](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-10025)
Missing clusterRole for listing pods in graphql

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
```
Charts:      29 passed, 29 total
Test Suites: 49 passed, 49 total
Tests:       238 passed, 238 total
Snapshot:    0 passed, 0 total
Time:        22.542549726s
```
