### PR TITLE
[OBSDEF-9484] Add support of pravega and zookeeper pod affinity

### DIFF
--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -400,6 +400,38 @@ spec:
       debugLogging: {{ .Values.pravega.debugLogging }}
       controllerServiceAccountName: {{ .Release.Name }}-pravega
       segmentStoreServiceAccountName: {{ .Release.Name }}-pravega
+      {{- if eq .Values.pravega.controller.disableAntiAffinity false }}
+      controllerPodAffinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - pravega-controller
+              - key: pravega_cluster
+                operator: In
+                values:
+                - {{ .Release.Name }}-pvg
+            topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- if eq .Values.pravega.segmentStore.disableAntiAffinity false }}
+      segmentStorePodAffinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - pravega-segmentstore
+              - key: pravega_cluster
+                operator: In
+                values:
+                - {{ .Release.Name }}-pvg
+            topologyKey: kubernetes.io/hostname
+      {{- end }}
 
   storageServer:
     serviceAccount: {{ .Release.Name }}-storageserver

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -217,7 +217,7 @@ spec:
       serviceAccountName: {{.Release.Name}}-storageserver
       annotations:
 {{ include "common-lib.vsphere-emm-integrated_annotation" . | indent 8}}
-{{- if eq .Values.zookeeper.disableAntiAffinity false }}
+{{- if eq .Values.zookeeper.enableAntiAffinity true }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -412,7 +412,7 @@ spec:
       debugLogging: {{ .Values.pravega.debugLogging }}
       controllerServiceAccountName: {{ .Release.Name }}-pravega
       segmentStoreServiceAccountName: {{ .Release.Name }}-pravega
-      {{- if eq .Values.pravega.controller.disableAntiAffinity false }}
+      {{- if eq .Values.pravega.controller.enableAntiAffinity true }}
       controllerPodAffinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -428,7 +428,7 @@ spec:
                 - {{ .Release.Name }}-pvg
             topologyKey: kubernetes.io/hostname
       {{- end }}
-      {{- if eq .Values.pravega.segmentStore.disableAntiAffinity false }}
+      {{- if eq .Values.pravega.segmentStore.enableAntiAffinity true }}
       segmentStorePodAffinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -217,6 +217,18 @@ spec:
       serviceAccountName: {{.Release.Name}}-storageserver
       annotations:
 {{ include "common-lib.vsphere-emm-integrated_annotation" . | indent 8}}
+{{- if eq .Values.zookeeper.disableAntiAffinity false }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ .Release.Name }}-zookeeper
+            topologyKey: kubernetes.io/hostname
+{{- end }}
     labels:
       app: zookeeper
       component: zk

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -191,10 +191,10 @@ bookkeeper:
       volumeSize: 30Gi
     journal:
       # storageClassName:
-      volumeSize: 13Gi
+      volumeSize: 20Gi
     index:
       # storageClassName:
-      volumeSize: 1Gi
+      volumeSize: 2Gi
   options:
     emptyDirVolumeMounts: "heap-dump=/crash-dump,log=/opt/bookkeeper/logs"
     log:

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -123,10 +123,12 @@ pravega:
 #    replicas: 1
     service:
       type: ClusterIP
+    disableAntiAffinity: false
   segmentStore:
 #    replicas: 1
     service:
       type: ClusterIP
+    disableAntiAffinity: false
   debugLogging: false
   externalAccess:
     enabled: false

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -123,12 +123,12 @@ pravega:
     replicas: 2
     service:
       type: ClusterIP
-    disableAntiAffinity: false
+    enableAntiAffinity: true
   segmentStore:
 #    replicas: 1
     service:
       type: ClusterIP
-    disableAntiAffinity: false
+    enableAntiAffinity: true
   debugLogging: false
   externalAccess:
     enabled: false

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -120,7 +120,7 @@ pravega:
     pullPolicy: IfNotPresent
     tag: 0.9.1-2791.bafc8b7a2 # rfw-update-this pravega-docker-image
   controller:
-#    replicas: 1
+    replicas: 2
     service:
       type: ClusterIP
     disableAntiAffinity: false

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -205,6 +205,8 @@ zookeeper:
   # Override the number of nodes in the zookeeper cluster
   # replicas: 3
 
+  disableAntiAffinity: false
+
   image:
     repository: zookeeper
     tag: 0.2.10-179-74e8fd5 # rfw-update-this zookeeper-docker-image

--- a/ecs-cluster/values.yaml
+++ b/ecs-cluster/values.yaml
@@ -205,7 +205,7 @@ zookeeper:
   # Override the number of nodes in the zookeeper cluster
   # replicas: 3
 
-  disableAntiAffinity: false
+  enableAntiAffinity: true
 
   image:
     repository: zookeeper


### PR DESCRIPTION
## Purpose
[OBSDEF-9484](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9484)
Add support of pravega and zookeeper pod affinity

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/254/

The pravega pod affinity has been configured via paremeters as expected, with required pod anti-affinity as default

