### PR TITLE
OBSDEF-9481 - set finalizers in OpenShift for configmaps, pods and deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,8 @@ flexver: yqcheck graphqlver zookeeper-operatorver pravega-operatorver atlas-oper
 
 chart-dep: charts-dep
 charts-dep:
-	rm **/charts/**; \
-	rm -r **/tmpcharts; \
+	rm -f **/charts/**; \
+	rm -rf **/tmpcharts; \
 	if [ "$${CHARTS}" = "$${ALL_CHARTS}" ] ; then \
 		BUILD_CHARTS=`python tools/build_helper/sort_charts_by_deps.py -c ${CHARTS}`; \
 	else  \

--- a/kahm/templates/rbac.yaml
+++ b/kahm/templates/rbac.yaml
@@ -47,6 +47,7 @@ rules:
   - persistentvolumeclaims
   - events
   - configmaps
+  - configmaps/finalizers
   - secrets
   - applications
   - deployments

--- a/objectscale-manager/templates/operator-rbac.yaml
+++ b/objectscale-manager/templates/operator-rbac.yaml
@@ -60,6 +60,7 @@ rules:
   resources:
   - pods
   - pods/exec
+  - pods/finalizers
   - services
   - endpoints
   - persistentvolumeclaims
@@ -87,6 +88,7 @@ rules:
   - apps
   resources:
   - deployments
+  - deployments/finalizers
   - daemonsets
   - replicasets
   - statefulsets


### PR DESCRIPTION

## Purpose
[OBSDEF-9481](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-9481)
- for kahm healtchecks/CloudIQ set configmaps/finalizers
- for service procedure services set pods/finalizers & deployments/finalizers

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
### charts ci job:
https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/255/

### OpenShift install - healthchecks job & sp-operator services created:
```
─ $ ▶  kubectl get svc
NAME                                     TYPE           CLUSTER-IP       EXTERNAL-IP                            PORT(S)             AGE
fedsvc                                   ClusterIP      172.30.103.149   <none>                                 9500/TCP            25s
kahm-postgresql-ha-pgpool                ClusterIP      172.30.213.100   <none>                                 5432/TCP            41s
kahm-postgresql-ha-postgresql            ClusterIP      172.30.14.83     <none>                                 5432/TCP            41s
kahm-postgresql-ha-postgresql-headless   ClusterIP      None             <none>                                 5432/TCP            41s
kahm-restapi                             ClusterIP      172.30.52.66     <none>                                 17999/TCP           41s
kubernetes                               ClusterIP      172.30.0.1       <none>                                 443/TCP             76d
logging-injector                         ClusterIP      172.30.112.111   <none>                                 443/TCP             57s
o-installer                              ClusterIP      172.30.227.135   <none>                                 80/TCP              4m9s
objectscale-dcm                          ClusterIP      172.30.11.168    <none>                                 9026/TCP            25s
objectscale-gateway                      LoadBalancer   172.30.30.253    10.249.232.90,10.249.232.90            443:31937/TCP       8s
objectscale-gateway-internal             LoadBalancer   172.30.244.61    10.249.232.93,10.249.232.93            4443:30509/TCP      7s
objectscale-graphql                      ClusterIP      172.30.158.51    <none>                                 8080/TCP            4m9s
objectscale-iam                          ClusterIP      172.30.151.247   <none>                                 443/TCP,9400/TCP    6s
objectscale-iam-headless                 ClusterIP      None             <none>                                 9400/TCP,443/TCP    25s
objectscale-manager-fluxd                ClusterIP      172.30.172.211   <none>                                 8093/TCP            25s
objectscale-manager-grafana              ClusterIP      172.30.10.120    <none>                                 3000/TCP            25s
objectscale-manager-influxdb             ClusterIP      None             <none>                                 8086/TCP,8088/TCP   25s
objectscale-manager-rsyslog              ClusterIP      None             <none>                                 10514/TCP           25s
objectscale-manager-service-pod          ClusterIP      172.30.184.159   <none>                                 22/TCP              25s
objectscale-manager-telegraf             ClusterIP      172.30.85.194    <none>                                 11002/TCP           25s
objectscale-manager-throttler            ClusterIP      172.30.228.212   <none>                                 8094/TCP            25s
objectscale-operator-metrics             ClusterIP      172.30.128.218   <none>                                 8383/TCP            9s
objectscale-portal-external              LoadBalancer   172.30.104.170   10.249.232.92,10.249.232.92            4443:30845/TCP      4m9s
openshift                                ExternalName   <none>           kubernetes.default.svc.cluster.local   <none>              76d
sp-operator-metrics                      ClusterIP      172.30.184.215   <none>                                 8384/TCP            8s
epavkovi @ ubuntu-07 ~/src/emcecs/charts (bugfix-OBSDEF-9481-openshift-finalizers)
└─ $ ▶  kubectl get cronjobs.batch 
NAME                                SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
objectscale-manager-capacity        0 * * * *      False     0        <none>          23s
objectscale-manager-health          */10 * * * *   False     0        <none>          23s
objectscale-manager-inventory       0 * * * *      False     0        <none>          23s
objectscale-manager-license-usage   0 */6 * * *    False     0        <none>          23s
objectscale-manager-performance     */10 * * * *   False     0        <none>          23s
```

