### PR TITLE
[OBSDEF-8800] Stuck Suspending when Excluding Node in ObjectStore Creation

### DIFF
--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -46,7 +46,7 @@ spec:
                 operator: Out
                 values:
               {{- range .Values.topology.excludedFaultDomains }}
-              - {{ .name }}
+              - {{ . }}
                 {{- end }}
                 {{- end }}
                 # Limit scheduling to only those listed in the node selector


### PR DESCRIPTION
## Purpose
[OBSDEF-8800](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-8800)
_List the changes for this PR_
When excluding a node during ObjectStore Creation, would run into an issue where the helm value for .name could not be found. Changed {{ .name }} to {{ . }} as per https://helm.sh/docs/chart_template_guide/control_structures/#looping-with-the-range-action to resolve.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

