### PR TITLE
[OBSDEF-10108] Exit if build or update dep failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,12 +162,11 @@ charts-dep:
 	fi ; \
  	for CHART in $${BUILD_CHARTS}; do \
  		echo "Updating dependencies for $${CHART}" ; \
- 		helm dep up $${CHART}; \
+ 		helm dep up $${CHART} || exit $?; \
  	done ;
 
 resolve-versions:
 	python tools/build_helper/version_resolver.py -vs ${VERSION_SLICE_PATH}
-
 
 build:
 	if [ "$${CHARTS}" == "$${ALL_CHARTS}" ] ; then \
@@ -177,8 +176,8 @@ build:
 	fi ; \
 	for CHART in $${BUILD_CHARTS}; do \
 		echo "Updating package for $${CHART}" ; \
-		helm dep update $${CHART}; \
-		helm package $${CHART} --destination docs ; \
+		helm dep update $${CHART} || exit $?; \
+		helm package $${CHART} --destination docs || exit $?; \
 	done ; \
     cd docs && helm repo index . ;
 


### PR DESCRIPTION
## Purpose
https://jira.cec.lab.emc.com/browse/OBSDEF-10108

Added ` || exit $?` for the `helm dep up` and `helm package` commands

## PR checklist
- [x] make test passed
- [x] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
Now errors should not be ignored
```
Updating package for logging-injector
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/bereza/.kube/config
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://asdrepo.isus.emc.com/artifactory/objectscale-helm-build/" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "ecs2" chart repository
...Successfully got an update from the "ecs" chart repository
Update Complete. ⎈Happy Helming!⎈
Error: can't get a valid version for repositories logging-injector. Try changing the version constraint in Chart.yaml
Makefile:172: recipe for target 'build' failed
make: *** [build] Error 1
```

_Paste the output of your helm install/vSphere7 deployment testing here_

