### PR TITLE
clusterolebinding to change SCC to anyuid

### DIFF
--- a/kahm/templates/scc-rbac.yaml
+++ b/kahm/templates/scc-rbac.yaml
@@ -1,0 +1,17 @@
+---
+{{- if eq .Values.global.platform "OpenShift" }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Namespace }}-scc-anyuid
+  labels:
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: kahm
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name:  system:openshift:scc:anyuid
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
## Purpose
[OBSDEF-nnnn](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-nnnn)
This PR will allow KAHM pod/containers to run with SCC:anyuid on the OpenShift when it is running in a specific namespace.


## PR checklist
- [ ] make test passed
- [ ] make build passed
- [ ] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

