### PR TITLE
[OBSDEF-10597] Refactor SP operator ignore checks labels

### DIFF
--- a/common-lib/templates/_sp_operator_labels.yaml
+++ b/common-lib/templates/_sp_operator_labels.yaml
@@ -20,10 +20,16 @@ objectscale.dellemc.com/sp-integrated: "true"
 {{- end }}
 
 #
-# Label for registering for ignoring stateless pods readiness post check on TMM.
+# IgnoreChecksLabel Contains name of checks to be ignored during service procedures in the following format
+# 'fmt.Sprintf(%s-%s, <ServiceProcedureName>, <CheckName>)' E.g. PMM-EnoughCapacityPreCheck, TMM-PodsAreReadyPostCheck
+# Label may contain multiple checks to ignored split by the '_'
 #
-{{ define "common-lib.labels-sp-integrated-depends-on-stateful" -}}
-objectscale.dellemc.com/sp-integrated-depends-on-stateful: "true"
+# Example how to add ignore all PMM checks and TMM pod readiness precheck rules in the template:
+# {{ include "common-lib.labels-sp-integrated-ignore-checks" (dict "checks" "PMM-AllChecks_TMM-PodsAreReadyPreCheck") | indent 8}}
+#
+#
+{{ define "common-lib.labels-sp-integrated-ignore-checks" -}}
+objectscale.dellemc.com/sp-integrated-ignore-checks: "{{- .checks -}}"
 {{- end }}
 
 #

--- a/ecs-cluster/templates/ecs-cluster.yaml
+++ b/ecs-cluster/templates/ecs-cluster.yaml
@@ -367,11 +367,11 @@ spec:
       controllerPodLabels:
 {{ include "datasvc-lib.logging-inject-common-labels" . | indent 8}}
 {{ include "common-lib.labels-sp-integrated-all" . | indent 8}}
-{{ include "common-lib.labels-sp-integrated-depends-on-stateful" . | indent 8}}
+{{ include "common-lib.labels-sp-integrated-ignore-checks" (dict "checks" "TMM-PodsAreReadyPostCheck") | indent 8}}
       segmentStorePodLabels:
 {{ include "datasvc-lib.logging-inject-common-labels" . | indent 8}}
 {{ include "common-lib.labels-sp-integrated-all" . | indent 8}}
-{{ include "common-lib.labels-sp-integrated-depends-on-stateful" . | indent 8}}
+{{ include "common-lib.labels-sp-integrated-ignore-checks" (dict "checks" "TMM-PodsAreReadyPostCheck") | indent 8}}
       segmentStorePodAnnotations:
 {{ include "common-lib.vsphere-emm-integrated_annotation" . | indent 8}}
       controllerPodAnnotations:

--- a/objectscale-iam/values.yaml
+++ b/objectscale-iam/values.yaml
@@ -25,10 +25,10 @@ image:
 replicaCount: 3
 
 resources:
-    limits:
-      memory: 2.5Gi
-    requests:
-      memory: 2.5Gi
+  limits:
+    memory: 2.5Gi
+  requests:
+    memory: 2.5Gi
 
 # Liveness and Readiness Probe configurations for the ObjectScale IAM Deployment
 livenessProbe:


### PR DESCRIPTION
## Purpose
[OBSDEF-10597](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-10597)

_List the changes for this PR_
Replace `sp-integrated-depends-on-stateful` label for the sp operator with the new one to ignore TMM Post check for the pravega controller
Also fixed indentation in the iam values to pass `make test`

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/310/

Helm install dry-run
```
$helm install objstore ecs-cluster/ --dry-run
...
      controllerPodLabels:
        app.kubernetes.io/namespace: default
        objectscale.dellemc.com/logging-inject: "true"
        objectscale.dellemc.com/logging-release-name: "objstore"
        objectscale.dellemc.com/sp-integrated: "true"
        objectscale.dellemc.com/sp-integrated-ignore-checks: "TMM-PodsAreReadyPostCheck"
      segmentStorePodLabels:
        app.kubernetes.io/namespace: default
        objectscale.dellemc.com/logging-inject: "true"
        objectscale.dellemc.com/logging-release-name: "objstore"
        objectscale.dellemc.com/sp-integrated: "true"
        objectscale.dellemc.com/sp-integrated-ignore-checks: "TMM-PodsAreReadyPostCheck"
```