### PR TITLE
[OBSDEF-10711] statefuldaemonset-operator: add new roles

### DIFF
--- a/statefuldaemonset-operator/templates/role.yaml
+++ b/statefuldaemonset-operator/templates/role.yaml
@@ -13,6 +13,7 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  - persistentvolumeclaims/finalizers
   verbs:
   - create
   - get
@@ -24,6 +25,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
   verbs:
   - create
   - delete
@@ -36,6 +38,7 @@ rules:
   - stateful.ecs.dellemc.com
   resources:
   - statefuldaemonsets
+  - statefuldaemonsets/finalizers
   verbs:
   - create
   - delete

--- a/statefuldaemonset-operator/templates/role.yaml
+++ b/statefuldaemonset-operator/templates/role.yaml
@@ -10,13 +10,11 @@ metadata:
 {{ include "statefuldaemonset-operator.labels" . | indent 4}}
 rules:
 - apiGroups:
-  - apps
+  - ""
   resources:
-  - statefulsets
-  - statefulsets/finalizers
+  - persistentvolumeclaims
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -38,7 +36,6 @@ rules:
   - stateful.ecs.dellemc.com
   resources:
   - statefuldaemonsets
-  - statefuldaemonsets/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
[OBSDEF-10711](https://jira.cec.lab.emc.com/browse/OBSDEF-10711)
Same as https://github.com/EMCECS/charts/pull/966 but to `release-objectscale-1.0-beta3`.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [x] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

### Testing
https://asd-ecs-jenkins.isus.emc.com/job/monitoring-libs/job/objectscale-charts/job/feature-OBSDEF-10711-statefuldaemonset-operator-beta3/2/
