### PR TITLE
OBSDEF-5500 - Assign a memory limit to the service-pod that matches the memory request val

### DIFF
--- a/service-pod/values.yaml
+++ b/service-pod/values.yaml
@@ -35,4 +35,5 @@ resources:
     memory: 2Gi
     ephemeral-storage: 10Gi
   limits:
+    memory: 2Gi
     ephemeral-storage: 20Gi


### PR DESCRIPTION
## Purpose
OBSDEF-5500 - assign a fixed memory limit to the service pod of 2Gi, which should reduce the chances that kubelet decides to kill the pod to reclaim memory on an oversubscribed node.

## PR checklist
- [ ] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [ ] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/


