### PR TITLE
obsdef-12056 - Added API to fetch Build

### DIFF
--- a/objectscale-portal/templates/objectscale-portal-configmap.yaml
+++ b/objectscale-portal/templates/objectscale-portal-configmap.yaml
@@ -168,7 +168,7 @@ data:
                 return 200 '{{ .Values.features | toJson }}';
             }
 
-            location /build-details {
+            location /version {
                 return 200 '{{ .Chart.AppVersion }}';
             }
 

--- a/objectscale-portal/templates/objectscale-portal-configmap.yaml
+++ b/objectscale-portal/templates/objectscale-portal-configmap.yaml
@@ -163,9 +163,15 @@ data:
                 default_type application/json;
                 return 200 '{"value":"{{ .Values.global.platform }}"}';
             }
+            
             location /features {
                 return 200 '{{ .Values.features | toJson }}';
             }
+
+            location /build-details {
+                return 200 '{{ .Chart.AppVersion }}';
+            }
+
             location / {
                 add_header X-Frame-Options "SAMEORIGIN";
                 root   /usr/share/nginx/html;


### PR DESCRIPTION
## Purpose
[OBSDEF-12056](https://jira.cec.lab.emc.com:8443/browse/OBSDEF-12056)
Introduced new API to return the version of current deployment.  This build would be shown on the Login Page and on the Openshift/Standalone Menu.

## PR checklist
- [x] make test passed
- [x] make build passed
- [x] helm install <chart> passed
- [x] vSphere7 make package deployments passed
- [ ] helm upgrade <chart> passed
- [ ] helm test <release_name> passed
- [ ] Passed - https://asd-ecs-jenkins.isus.emc.com/jenkins/view/ECS-Flex/job/charts-custom-ci/

## Testing
_Paste URL of charts-custom-ci job here_

_Paste the output of your helm install/vSphere7 deployment testing here_

_After genearating package:_
![image](https://user-images.githubusercontent.com/54625112/134364879-0619c870-1074-4525-a630-81f37528c292.png)



